### PR TITLE
Make the noop and Tensorflow collectors generic

### DIFF
--- a/sticker-utils/src/bin/sticker-prepare.rs
+++ b/sticker-utils/src/bin/sticker-prepare.rs
@@ -9,7 +9,7 @@ use getopts::Options;
 use serde_derive::Serialize;
 use stdinout::{Input, OrExit, Output};
 
-use sticker::{Collector, Embeddings, NoopCollector, Numberer, SentVectorizer};
+use sticker::{Collector, Embeddings, LayerEncoder, NoopCollector, Numberer, SentVectorizer};
 use sticker_utils::{CborWrite, Config, TomlRead};
 
 /// Ad-hoc shapes structure, which can be used to construct the
@@ -71,7 +71,8 @@ fn main() {
         .or_exit("Cannot load embeddings", 1);
     let vectorizer = SentVectorizer::new(embeddings);
 
-    let mut collector = NoopCollector::new(config.labeler.layer.clone(), labels, vectorizer);
+    let encoder = LayerEncoder::new(config.labeler.layer.clone());
+    let mut collector = NoopCollector::new(encoder, labels, vectorizer);
 
     for sentence in treebank_reader.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);

--- a/sticker-utils/src/bin/sticker-train.rs
+++ b/sticker-utils/src/bin/sticker-train.rs
@@ -12,7 +12,7 @@ use stdinout::OrExit;
 use sticker::tensorflow::{
     CollectedTensors, LearningRateSchedule, Tagger, TaggerGraph, TensorCollector,
 };
-use sticker::{Collector, Numberer, SentVectorizer};
+use sticker::{Collector, LayerEncoder, Numberer, SentVectorizer};
 use sticker_utils::{CborRead, Config, FileProgress, TomlRead};
 
 fn print_usage(program: &str, opts: Options) {
@@ -202,12 +202,8 @@ where
         FileProgress::new(input_file).or_exit("Cannot create file progress bar", 1),
     ));
 
-    let mut collector = TensorCollector::new(
-        config.model.batch_size,
-        config.labeler.layer.clone(),
-        labels,
-        vectorizer,
-    );
+    let encoder = LayerEncoder::new(config.labeler.layer.clone());
+    let mut collector = TensorCollector::new(config.model.batch_size, encoder, labels, vectorizer);
     for sentence in reader.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);
         collector

--- a/sticker/src/encoder.rs
+++ b/sticker/src/encoder.rs
@@ -1,0 +1,43 @@
+use conllx::graph::{Node, Sentence};
+use failure::{format_err, Error};
+
+use crate::{Layer, LayerValue};
+
+/// Trait for sentence encoders.
+///
+/// A sentence encoder extracts a representation of each token in a
+/// sentence, such as a part-of-speech tag or a topological field.
+pub trait SentenceEncoder {
+    type Encoding;
+
+    /// Encode the given sentence.
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error>;
+}
+
+/// Encode sentences using a CoNLL-X layer.
+pub struct LayerEncoder {
+    layer: Layer,
+}
+
+impl LayerEncoder {
+    /// Construct a new layer encoder of the given layer.
+    pub fn new(layer: Layer) -> Self {
+        LayerEncoder { layer }
+    }
+}
+
+impl SentenceEncoder for LayerEncoder {
+    type Encoding = String;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+        let mut encoding = Vec::with_capacity(sentence.len() - 1);
+        for token in sentence.iter().filter_map(Node::token) {
+            let label = token
+                .value(&self.layer)
+                .ok_or_else(|| format_err!("Token without a label: {}", token.form()))?;
+            encoding.push(label.to_owned());
+        }
+
+        Ok(encoding)
+    }
+}

--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -1,6 +1,9 @@
 mod collector;
 pub use crate::collector::{Collector, NoopCollector};
 
+mod encoder;
+pub use crate::encoder::{LayerEncoder, SentenceEncoder};
+
 mod input;
 pub use crate::input::{Embeddings, LayerEmbeddings, SentVectorizer};
 


### PR DESCRIPTION
Both collectors assumed that the labels were of type String. This
change introduces the SentenceEncoder trait that encodes the tokens.
The collected type is an associated type of SentenceEncoder.