### PR TITLE
Make the Tag trait and the Tensorflow Tagger implementation generic

### DIFF
--- a/sticker-utils/src/bin/sticker-tag.rs
+++ b/sticker-utils/src/bin/sticker-tag.rs
@@ -10,7 +10,7 @@ use getopts::Options;
 use stdinout::{Input, OrExit, Output};
 
 use sticker::tensorflow::{Tagger, TaggerGraph};
-use sticker::{Numberer, SentVectorizer};
+use sticker::{LayerEncoder, Numberer, SentVectorizer};
 use sticker_utils::{CborRead, Config, SentProcessor, TomlRead};
 
 fn print_usage(program: &str, opts: Options) {
@@ -78,8 +78,9 @@ fn main() {
     let tagger = Tagger::load_weights(graph, labels, vectorizer, config.model.parameters)
         .or_exit("Cannot construct tagger", 1);
 
+    let decoder = LayerEncoder::new(config.labeler.layer.clone());
     let mut sent_proc = SentProcessor::new(
-        config.labeler.layer.clone(),
+        decoder,
         &tagger,
         writer,
         config.model.batch_size,

--- a/sticker-utils/src/bin/sticker-train.rs
+++ b/sticker-utils/src/bin/sticker-train.rs
@@ -130,7 +130,7 @@ fn train_model(
 }
 
 fn run_epoch(
-    tagger: &Tagger,
+    tagger: &Tagger<String>,
     tensors: &CollectedTensors,
     is_training: bool,
     lr: f32,

--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -2,7 +2,7 @@ mod collector;
 pub use crate::collector::{Collector, NoopCollector};
 
 mod encoder;
-pub use crate::encoder::{LayerEncoder, SentenceEncoder};
+pub use crate::encoder::{LayerEncoder, SentenceDecoder, SentenceEncoder};
 
 mod input;
 pub use crate::input::{Embeddings, LayerEmbeddings, SentVectorizer};

--- a/sticker/src/tag.rs
+++ b/sticker/src/tag.rs
@@ -62,8 +62,8 @@ impl LayerValue for Token {
 }
 
 /// Trait for sequence taggers.
-pub trait Tag {
-    fn tag_sentences(&self, sentences: &[impl Borrow<Sentence>]) -> Result<Vec<Vec<&str>>, Error>;
+pub trait Tag<T> {
+    fn tag_sentences(&self, sentences: &[impl Borrow<Sentence>]) -> Result<Vec<Vec<&T>>, Error>;
 }
 
 /// Results of validation.


### PR DESCRIPTION
The Tagger type had `Numberer<String>`, replace by `Numberer<T>`. Also
provide a `SentenceDecoder` trait with an implementation for
`LayerEncoder`. This is now used by `SentProcessor` to update the
sentences.