### PR TITLE
write-graph: Add an option for multiple RNN layers

### DIFF
--- a/sticker-utils/tensorflow/config.py
+++ b/sticker-utils/tensorflow/config.py
@@ -10,6 +10,7 @@ class DefaultConfig:
     keep_prob_input = 0.80
     kernel_size = 3
     n_levels = 7
+    rnn_layers = 1
 
 
 def path_relative_to_conf(conf_path, file_path):

--- a/sticker-utils/tensorflow/rnn_model.py
+++ b/sticker-utils/tensorflow/rnn_model.py
@@ -74,7 +74,7 @@ class RNNModel(Model):
         (fstates, bstates), _ = rnn_layers(
             self.is_training,
             inputs,
-            num_layers=1,
+            num_layers=config.rnn_layers,
             output_size=config.hidden_size,
             output_dropout=config.keep_prob,
             state_dropout=config.keep_prob,

--- a/sticker-utils/tensorflow/write-graph
+++ b/sticker-utils/tensorflow/write-graph
@@ -85,6 +85,11 @@ if __name__ == '__main__':
         help="number of dilated convolution levels",
         default=7)
     parser.add_argument(
+        "--rnn_layers",
+        type=int,
+        help="stacked RNN layers",
+        default=1)
+    parser.add_argument(
         '--type',
         metavar='MODEL_TYPE',
         type=str,
@@ -101,9 +106,10 @@ if __name__ == '__main__':
     config.keep_prob_input = args.keep_prob_input
     config.kernel_size = args.kernel_size
     config.n_levels = args.levels
+    config.rnn_layers = args.rnn_layers
 
     if args.type == 'rnn':
-        print("Model: rnn, gru: %r, crf: %r" % (config.gru, config.crf))
+        print("Model: rnn, gru: %r, crf: %r, layers: %d" % (config.gru, config.crf, config.rnn_layers))
         model = RNNModel
     elif args.type == 'conv':
         model = ConvModel


### PR DESCRIPTION
Dependency parsing works better with two bidi layers, so make this customizable.