### PR TITLE
Add the relative part-of-speech position dependency encoder

### DIFF
--- a/sticker/src/depparse/errors.rs
+++ b/sticker/src/depparse/errors.rs
@@ -22,4 +22,8 @@ pub(crate) enum DecodeError {
     /// The head position is out of bounds.
     #[fail(display = "position out of bounds")]
     PositionOutOfBounds,
+
+    /// The head part-of-speech tag does not occur in the sentence.
+    #[fail(display = "unknown part-of-speech tag")]
+    InvalidPOS,
 }

--- a/sticker/src/depparse/mod.rs
+++ b/sticker/src/depparse/mod.rs
@@ -6,6 +6,9 @@ pub use crate::depparse::errors::*;
 mod relative_position;
 pub use crate::depparse::relative_position::*;
 
+mod relative_pos;
+pub use crate::depparse::relative_pos::*;
+
 /// Encoding of a dependency relation as a token label.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct DependencyEncoding<H> {
@@ -34,7 +37,7 @@ mod tests {
     use conllx::graph::{Node, Sentence};
     use conllx::io::Reader;
 
-    use super::RelativePositionEncoder;
+    use super::{RelativePOSEncoder, RelativePositionEncoder};
     use crate::{SentenceDecoder, SentenceEncoder};
 
     static NON_PROJECTIVE_DATA: &'static str = "testdata/nonprojective.conll";
@@ -70,6 +73,12 @@ mod tests {
 
             assert_eq!(sentence, test_sentence);
         }
+    }
+
+    #[test]
+    fn relative_pos_position() {
+        let encoder = RelativePOSEncoder;
+        test_encoding(NON_PROJECTIVE_DATA, encoder);
     }
 
     #[test]

--- a/sticker/src/depparse/relative_pos.rs
+++ b/sticker/src/depparse/relative_pos.rs
@@ -1,0 +1,307 @@
+use std::borrow::Borrow;
+use std::collections::HashMap;
+
+use conllx::graph::{DepTriple, Node, Sentence};
+use failure::Error;
+use serde_derive::{Deserialize, Serialize};
+
+use super::{DecodeError, DependencyEncoding, EncodeError};
+use crate::{SentenceDecoder, SentenceEncoder, SentenceTopKDecoder};
+
+/// Relative head position by part-of-speech.
+///
+/// The position of the head relative to the dependent token,
+/// in terms of part-of-speech tags. For example, a position of
+/// *-2* with the pos *noun* means that the head is the second
+/// preceding noun.
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct RelativePOS {
+    position: isize,
+    pos: String,
+}
+
+/// Relative part-of-speech position encoder.
+///
+/// This encoder encodes dependency relations as token labels. The
+/// dependency relation is encoded as-is. The position of the head
+/// is encoded relative to the (dependent) token by part-of-speech.
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RelativePOSEncoder;
+
+impl RelativePOSEncoder {
+    fn decode_idx(
+        pos_table: &HashMap<String, Vec<usize>>,
+        idx: usize,
+        encoding: &DependencyEncoding<RelativePOS>,
+    ) -> Result<DepTriple<String>, DecodeError> {
+        let DependencyEncoding { label, head } = encoding;
+
+        let indices = pos_table
+            .get(head.pos.as_str())
+            .ok_or(DecodeError::InvalidPOS)?;
+
+        let head_idx = Self::head_index(indices, idx, head.position)?;
+
+        Ok(DepTriple::new(head_idx, Some(label.to_owned()), idx))
+    }
+
+    /// Find the relative position of a dependent to a head.
+    ///
+    /// This methods finds the relative position of `dependent` to
+    /// `head` in `indices`.
+    fn relative_dependent_position(indices: &[usize], head: usize, dependent: usize) -> isize {
+        let mut head_position = indices
+            .binary_search(&head)
+            .expect("Head is missing in sorted POS tag list");
+
+        let dependent_position = match indices.binary_search(&dependent) {
+            Ok(idx) => idx,
+            Err(idx) => {
+                // The head moves one place if the dependent is inserted
+                // before the head. Consider e.g. the indices
+                //
+                // [3, 6, 9]
+                //     ^--- insertion point of 4.
+                //
+                // Suppose that we want to compute the relative
+                // position of 4 to its head 9 (position 2). The
+                // insertion point is 1. When computing the relative
+                // position, we should take into account that 4 lies
+                // before 6.
+                if dependent < head {
+                    head_position += 1;
+                }
+                idx
+            }
+        };
+
+        head_position as isize - dependent_position as isize
+    }
+
+    /// Get the index of the head of `dependent`.
+    ///
+    /// Get index of the head of `dependent`, given the relative
+    /// position of `dependent` to the head in `indices`.
+    fn head_index(
+        indices: &[usize],
+        dependent: usize,
+        mut relative_head_position: isize,
+    ) -> Result<usize, DecodeError> {
+        let dependent_position = match indices.binary_search(&dependent) {
+            Ok(idx) => idx,
+            Err(idx) => {
+                // Consider e.g. the indices
+                //
+                // [3, 6, 9]
+                //     ^--- insertion point of 4.
+                //
+                // Suppose that 4 is the dependent and +2 the relative
+                // position of the head. The relative position takes
+                // both succeeding elements (6, 9) into
+                // account. However, the insertion point is the
+                // element at +1. So, compensate for this in the
+                // relative position.
+                if relative_head_position > 0 {
+                    relative_head_position -= 1
+                }
+                idx
+            }
+        };
+
+        let head_position = dependent_position as isize + relative_head_position;
+        if head_position < 0 || head_position >= indices.len() as isize {
+            return Err(DecodeError::PositionOutOfBounds);
+        }
+
+        Ok(indices[head_position as usize])
+    }
+}
+
+impl SentenceEncoder for RelativePOSEncoder {
+    type Encoding = DependencyEncoding<RelativePOS>;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+        let pos_table = pos_position_table(&sentence);
+
+        let mut encoded = Vec::with_capacity(sentence.len());
+        for idx in 0..sentence.len() {
+            let token = &sentence[idx];
+            if token.is_root() {
+                continue;
+            }
+
+            let triple = sentence
+                .dep_graph()
+                .head(idx)
+                .ok_or(EncodeError::MissingHead)?;
+            let relation = triple.relation().ok_or(EncodeError::MissingRelation)?;
+
+            let head_pos = match &sentence[triple.head()] {
+                Node::Root => "ROOT",
+                Node::Token(head_token) => head_token.pos().ok_or(EncodeError::MissingPOS)?,
+            };
+
+            let position = Self::relative_dependent_position(
+                &pos_table[head_pos],
+                triple.head(),
+                triple.dependent(),
+            );
+
+            encoded.push(DependencyEncoding {
+                label: relation.to_owned(),
+                head: RelativePOS {
+                    pos: head_pos.to_owned(),
+                    position,
+                },
+            });
+        }
+
+        Ok(encoded)
+    }
+}
+
+impl SentenceDecoder for RelativePOSEncoder {
+    type Encoding = DependencyEncoding<RelativePOS>;
+
+    fn decode<E>(&self, labels: &[E], sentence: &mut Sentence) -> Result<(), Error>
+    where
+        E: Borrow<Self::Encoding>,
+    {
+        // This rewrapping has some potential overhead due to the auxiliary
+        // Vec. But this avoids having two separate implementations for
+        // decoding.
+        let labels = labels.iter().map(|e| [e.borrow()]).collect::<Vec<_>>();
+        self.decode_top_k(&labels, sentence)
+    }
+}
+
+impl SentenceTopKDecoder for RelativePOSEncoder {
+    type Encoding = DependencyEncoding<RelativePOS>;
+
+    fn decode_top_k<S, E>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    where
+        E: Borrow<Self::Encoding>,
+        S: AsRef<[E]>,
+    {
+        let pos_table = pos_position_table(&sentence);
+
+        let token_indices: Vec<_> = (0..sentence.len())
+            .filter(|&idx| sentence[idx].is_token())
+            .collect();
+
+        for (idx, encodings) in token_indices.into_iter().zip(labels) {
+            for encoding in encodings.as_ref() {
+                if let Ok(triple) =
+                    RelativePOSEncoder::decode_idx(&pos_table, idx, encoding.borrow())
+                {
+                    sentence.dep_graph_mut().add_deprel(triple);
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn pos_position_table(sentence: &Sentence) -> HashMap<String, Vec<usize>> {
+    let mut table = HashMap::new();
+
+    for (idx, node) in sentence.iter().enumerate() {
+        let pos = match node {
+            Node::Root => "ROOT".into(),
+            Node::Token(token) => match token.pos() {
+                Some(pos) => pos.into(),
+                None => continue,
+            },
+        };
+
+        let indices = table.entry(pos).or_insert_with(|| vec![]);
+        indices.push(idx);
+    }
+
+    table
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::iter::FromIterator;
+
+    use conllx::graph::{DepTriple, Sentence};
+    use conllx::token::TokenBuilder;
+
+    use super::{RelativePOS, RelativePOSEncoder};
+    use crate::depparse::{DecodeError, DependencyEncoding};
+    use crate::SentenceTopKDecoder;
+
+    // Small tests for relative part-of-speech encoder. Automatic
+    // testing is performed in the module tests.
+
+    #[test]
+    fn invalid_pos() {
+        assert_eq!(
+            RelativePOSEncoder::decode_idx(
+                &HashMap::new(),
+                0,
+                &DependencyEncoding {
+                    label: "X".into(),
+                    head: RelativePOS {
+                        pos: "C".into(),
+                        position: -1,
+                    },
+                },
+            ),
+            Err(DecodeError::InvalidPOS)
+        )
+    }
+
+    #[test]
+    fn position_out_of_bounds() {
+        assert_eq!(
+            RelativePOSEncoder::decode_idx(
+                &HashMap::from_iter(vec![("A".to_string(), vec![0])]),
+                1,
+                &DependencyEncoding {
+                    label: "X".into(),
+                    head: RelativePOS {
+                        pos: "A".into(),
+                        position: -2,
+                    },
+                },
+            ),
+            Err(DecodeError::PositionOutOfBounds)
+        )
+    }
+
+    #[test]
+    fn backoff() {
+        let mut sent = Sentence::new();
+        sent.push(TokenBuilder::new("a").pos("A").into());
+
+        let decoder = RelativePOSEncoder;
+        let labels = vec![vec![
+            DependencyEncoding {
+                label: "ROOT".into(),
+                head: RelativePOS {
+                    pos: "ROOT".into(),
+                    position: -2,
+                },
+            },
+            DependencyEncoding {
+                label: "ROOT".into(),
+                head: RelativePOS {
+                    pos: "ROOT".into(),
+                    position: -1,
+                },
+            },
+        ]];
+
+        decoder.decode_top_k(&labels, &mut sent).unwrap();
+
+        assert_eq!(
+            sent.dep_graph().head(1),
+            Some(DepTriple::new(0, Some("ROOT"), 1))
+        );
+    }
+}


### PR DESCRIPTION
This encoder encodes the head as a relative position by part-of-speech
to a (dependent) token.

This PR should be reviewed/merged after #8.