### PR TITLE
Support parsing in all the utilities

### DIFF
--- a/sticker-utils/src/bin/sticker-server.rs
+++ b/sticker-utils/src/bin/sticker-server.rs
@@ -1,20 +1,22 @@
 use std::env::args;
 use std::fs::File;
+use std::hash::Hash;
 use std::io::{BufReader, BufWriter, Write};
 use std::net::{TcpListener, TcpStream};
-use std::path::Path;
 use std::process;
 use std::sync::Arc;
 
 use conllx::io::{ReadSentence, Reader, Writer};
-use failure::Error;
 use getopts::Options;
 use stdinout::OrExit;
 use threadpool::ThreadPool;
 
+use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{Tagger, TaggerGraph};
-use sticker::{LayerEncoder, Numberer, SentVectorizer};
-use sticker_utils::{CborRead, Config, SentProcessor, TomlRead};
+use sticker::{LayerEncoder, Numberer, SentVectorizer, SentenceDecoder, SentenceTopKDecoder};
+use sticker_utils::{
+    CborRead, Config, EncoderType, LabelerType, SentProcessor, SentTopKProcessor, TomlRead,
+};
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} [options] CONFIG [INPUT] [OUTPUT]", program);
@@ -63,11 +65,6 @@ fn main() {
         .relativize_paths(&matches.free[0])
         .or_exit("Cannot relativize paths in configuration", 1);
 
-    let labels = load_labels(&config).or_exit(
-        format!("Cannot load label file '{}'", config.labeler.labels),
-        1,
-    );
-
     // Parallel processing is useless without the same parallelism in Tensorflow.
     config.model.inter_op_parallelism_threads = n_threads;
     config.model.intra_op_parallelism_threads = n_threads;
@@ -88,29 +85,84 @@ fn main() {
 
     let graph = TaggerGraph::load_graph(graph_reader, &config.model)
         .or_exit("Cannot load computation graph", 1);
+
+    let pool = ThreadPool::new(n_threads);
+
+    let addr = &matches.free[1];
+    let listener = TcpListener::bind(addr).or_exit(format!("Cannot listen on '{}'", addr), 1);
+
+    match config.labeler.labeler_type {
+        LabelerType::Sequence(ref layer) => serve_with_decoder(
+            &config,
+            pool,
+            vectorizer,
+            graph,
+            LayerEncoder::new(layer.clone()),
+            listener,
+        ),
+        LabelerType::Parser(EncoderType::RelativePOS) => serve_with_top_k_decoder(
+            &config,
+            pool,
+            vectorizer,
+            graph,
+            RelativePOSEncoder,
+            listener,
+        ),
+        LabelerType::Parser(EncoderType::RelativePosition) => serve_with_top_k_decoder(
+            &config,
+            pool,
+            vectorizer,
+            graph,
+            RelativePositionEncoder,
+            listener,
+        ),
+    }
+}
+
+fn serve_with_decoder<D>(
+    config: &Config,
+    pool: ThreadPool,
+    vectorizer: SentVectorizer,
+    graph: TaggerGraph,
+    decoder: D,
+    listener: TcpListener,
+) where
+    D: 'static + Clone + Send + SentenceDecoder,
+    D::Encoding: Clone + Eq + Hash + Send + Sync,
+    Numberer<D::Encoding>: CborRead,
+{
+    let labels = config.labeler.load_labels().or_exit(
+        format!("Cannot load label file '{}'", config.labeler.labels),
+        1,
+    );
+
     let tagger = Arc::new(
         Tagger::load_weights(graph, labels, vectorizer, config.model.parameters.clone())
             .or_exit("Cannot construct tagger", 1),
     );
 
-    let addr = &matches.free[1];
-    let pool = ThreadPool::new(n_threads);
-
-    let listener = TcpListener::bind(addr).or_exit(format!("Cannot listen on '{}'", addr), 1);
-
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
                 let config = config.clone();
+                let decoder = decoder.clone();
                 let tagger = tagger.clone();
-                pool.execute(move || handle_client(config, tagger, stream))
+                pool.execute(move || handle_client_with_decoder(config, tagger, decoder, stream))
             }
             Err(err) => eprintln!("Error processing stream: {}", err),
         }
     }
 }
 
-fn handle_client(config: Config, tagger: Arc<Tagger<String>>, mut stream: TcpStream) {
+fn handle_client_with_decoder<D>(
+    config: Config,
+    tagger: Arc<Tagger<D::Encoding>>,
+    decoder: D,
+    mut stream: TcpStream,
+) where
+    D: SentenceDecoder,
+    D::Encoding: Clone + Eq + Hash,
+{
     let peer_addr = stream
         .peer_addr()
         .map(|addr| addr.to_string())
@@ -128,7 +180,6 @@ fn handle_client(config: Config, tagger: Arc<Tagger<String>>, mut stream: TcpStr
     let reader = Reader::new(BufReader::new(&conllx_stream));
     let writer = Writer::new(BufWriter::new(&conllx_stream));
 
-    let decoder = LayerEncoder::new(config.labeler.layer.clone());
     let mut sent_proc = SentProcessor::new(
         decoder,
         &*tagger,
@@ -154,11 +205,90 @@ fn handle_client(config: Config, tagger: Arc<Tagger<String>>, mut stream: TcpStr
     eprintln!("Finished processing for {}", peer_addr);
 }
 
-fn load_labels(config: &Config) -> Result<Numberer<String>, Error> {
-    let labels_path = Path::new(&config.labeler.labels);
+fn serve_with_top_k_decoder<D>(
+    config: &Config,
+    pool: ThreadPool,
+    vectorizer: SentVectorizer,
+    graph: TaggerGraph,
+    decoder: D,
+    listener: TcpListener,
+) where
+    D: 'static + Clone + Send + SentenceTopKDecoder,
+    D::Encoding: Clone + Eq + Hash + Send + Sync,
+    Numberer<D::Encoding>: CborRead,
+{
+    let labels = config.labeler.load_labels().or_exit(
+        format!("Cannot load label file '{}'", config.labeler.labels),
+        1,
+    );
 
-    eprintln!("Loading labels from: {:?}", labels_path);
+    let tagger = Arc::new(
+        Tagger::load_weights(graph, labels, vectorizer, config.model.parameters.clone())
+            .or_exit("Cannot construct tagger", 1),
+    );
 
-    let f = File::open(labels_path)?;
-    Numberer::from_cbor_read(f)
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let config = config.clone();
+                let decoder = decoder.clone();
+                let tagger = tagger.clone();
+                pool.execute(move || {
+                    handle_client_with_top_k_decoder(config, tagger, decoder, stream)
+                })
+            }
+            Err(err) => eprintln!("Error processing stream: {}", err),
+        }
+    }
+}
+
+fn handle_client_with_top_k_decoder<D>(
+    config: Config,
+    tagger: Arc<Tagger<D::Encoding>>,
+    decoder: D,
+    mut stream: TcpStream,
+) where
+    D: SentenceTopKDecoder,
+    D::Encoding: Clone + Eq + Hash,
+{
+    let peer_addr = stream
+        .peer_addr()
+        .map(|addr| addr.to_string())
+        .unwrap_or_else(|_| "<unknown>".to_string());
+    eprintln!("Accepted connection from {}", peer_addr);
+
+    let conllx_stream = match stream.try_clone() {
+        Ok(stream) => stream,
+        Err(err) => {
+            eprintln!("Cannot clone stream: {}", err);
+            return;
+        }
+    };
+
+    let reader = Reader::new(BufReader::new(&conllx_stream));
+    let writer = Writer::new(BufWriter::new(&conllx_stream));
+
+    let mut sent_proc = SentTopKProcessor::new(
+        decoder,
+        &*tagger,
+        writer,
+        config.model.batch_size,
+        config.labeler.read_ahead,
+    );
+
+    for sentence in reader.sentences() {
+        let sentence = match sentence {
+            Ok(sentence) => sentence,
+            Err(err) => {
+                let _ = writeln!(stream, "! Cannot parse sentence: {}", err);
+                return;
+            }
+        };
+        if let Err(err) = sent_proc.process(sentence) {
+            let _ = writeln!(stream, "! Error processing sentence: {}", err);
+            return;
+        }
+    }
+
+    eprintln!("Finished processing for {}", peer_addr);
 }

--- a/sticker-utils/src/bin/sticker-tag.rs
+++ b/sticker-utils/src/bin/sticker-tag.rs
@@ -1,17 +1,19 @@
 use std::env::args;
 use std::fs::File;
+use std::hash::Hash;
 use std::io::BufWriter;
-use std::path::Path;
 use std::process;
 
-use conllx::io::{ReadSentence, Reader, Writer};
-use failure::Error;
+use conllx::io::{ReadSentence, Reader, WriteSentence, Writer};
 use getopts::Options;
 use stdinout::{Input, OrExit, Output};
 
+use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{Tagger, TaggerGraph};
-use sticker::{LayerEncoder, Numberer, SentVectorizer};
-use sticker_utils::{CborRead, Config, SentProcessor, TomlRead};
+use sticker::{LayerEncoder, Numberer, SentVectorizer, SentenceDecoder, SentenceTopKDecoder};
+use sticker_utils::{
+    CborRead, Config, EncoderType, LabelerType, SentProcessor, SentTopKProcessor, TomlRead,
+};
 
 fn print_usage(program: &str, opts: Options) {
     let brief = format!("Usage: {} [options] CONFIG [INPUT] [OUTPUT]", program);
@@ -54,11 +56,6 @@ fn main() {
         output.write().or_exit("Cannot open output for writing", 1),
     ));
 
-    let labels = load_labels(&config).or_exit(
-        format!("Cannot load label file '{}'", config.labeler.labels),
-        1,
-    );
-
     let embeddings = config
         .embeddings
         .load_embeddings()
@@ -75,30 +72,106 @@ fn main() {
     let graph = TaggerGraph::load_graph(graph_reader, &config.model)
         .or_exit("Cannot load computation graph", 1);
 
-    let tagger = Tagger::load_weights(graph, labels, vectorizer, config.model.parameters)
+    match config.labeler.labeler_type {
+        LabelerType::Sequence(ref layer) => process_with_decoder(
+            &config,
+            vectorizer,
+            graph,
+            LayerEncoder::new(layer.clone()),
+            reader,
+            writer,
+        ),
+        LabelerType::Parser(EncoderType::RelativePOS) => process_with_top_k_decoder(
+            &config,
+            vectorizer,
+            graph,
+            RelativePOSEncoder,
+            reader,
+            writer,
+        ),
+        LabelerType::Parser(EncoderType::RelativePosition) => process_with_top_k_decoder(
+            &config,
+            vectorizer,
+            graph,
+            RelativePositionEncoder,
+            reader,
+            writer,
+        ),
+    };
+}
+
+fn process_with_decoder<D, R, W>(
+    config: &Config,
+    vectorizer: SentVectorizer,
+    graph: TaggerGraph,
+    decoder: D,
+    read: R,
+    write: W,
+) where
+    D: SentenceDecoder,
+    D::Encoding: Clone + Eq + Hash,
+    Numberer<D::Encoding>: CborRead,
+    R: ReadSentence,
+    W: WriteSentence,
+{
+    let labels = config.labeler.load_labels().or_exit(
+        format!("Cannot load label file '{}'", config.labeler.labels),
+        1,
+    );
+
+    let tagger = Tagger::load_weights(graph, labels, vectorizer, &config.model.parameters)
         .or_exit("Cannot construct tagger", 1);
 
-    let decoder = LayerEncoder::new(config.labeler.layer.clone());
     let mut sent_proc = SentProcessor::new(
         decoder,
         &tagger,
-        writer,
+        write,
         config.model.batch_size,
         config.labeler.read_ahead,
     );
 
-    for sentence in reader.sentences() {
+    for sentence in read.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);
         sent_proc
             .process(sentence)
             .or_exit("Error processing sentence", 1);
     }
 }
-fn load_labels(config: &Config) -> Result<Numberer<String>, Error> {
-    let labels_path = Path::new(&config.labeler.labels);
 
-    eprintln!("Loading labels from: {:?}", labels_path);
+fn process_with_top_k_decoder<D, R, W>(
+    config: &Config,
+    vectorizer: SentVectorizer,
+    graph: TaggerGraph,
+    decoder: D,
+    read: R,
+    write: W,
+) where
+    D: SentenceTopKDecoder,
+    D::Encoding: Clone + Eq + Hash,
+    Numberer<D::Encoding>: CborRead,
+    R: ReadSentence,
+    W: WriteSentence,
+{
+    let labels = config.labeler.load_labels().or_exit(
+        format!("Cannot load label file '{}'", config.labeler.labels),
+        1,
+    );
 
-    let f = File::open(labels_path)?;
-    Numberer::from_cbor_read(f)
+    let tagger = Tagger::load_weights(graph, labels, vectorizer, &config.model.parameters)
+        .or_exit("Cannot construct tagger", 1);
+
+    let mut sent_proc = SentTopKProcessor::new(
+        decoder,
+        &tagger,
+        write,
+        config.model.batch_size,
+        config.labeler.read_ahead,
+    );
+
+    for sentence in read.sentences() {
+        let sentence = sentence.or_exit("Cannot parse sentence", 1);
+        sent_proc
+            .process(sentence)
+            .or_exit("Error processing sentence", 1);
+    }
 }

--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -5,12 +5,12 @@ use ordered_float::NotNan;
 use sticker::tensorflow::{ModelConfig, OpNames};
 use sticker::Layer;
 
-use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, TomlRead, Train};
+use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead, Train};
 
 lazy_static! {
     static ref BASIC_LABELER_CHECK: Config = Config {
         labeler: Labeler {
-            layer: Layer::Feature("tf".to_string()),
+            labeler_type: LabelerType::Sequence(Layer::Feature("tf".to_string())),
             labels: "sticker.labels".to_owned(),
             read_ahead: 10,
         },

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -1,11 +1,13 @@
 mod config;
-pub use crate::config::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, Train};
+pub use crate::config::{
+    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Labeler, LabelerType, Train,
+};
 
 mod progress;
 pub use crate::progress::FileProgress;
 
 mod sent_proc;
-pub use crate::sent_proc::SentProcessor;
+pub use crate::sent_proc::{SentProcessor, SentTopKProcessor};
 
 mod serialization;
 pub use crate::serialization::{CborRead, CborWrite, TomlRead};

--- a/sticker-utils/src/sent_proc.rs
+++ b/sticker-utils/src/sent_proc.rs
@@ -1,9 +1,7 @@
-use std::io::Write;
-
 use conllx::graph::Sentence;
-use conllx::io::{WriteSentence, Writer};
+use conllx::io::WriteSentence;
 use failure::Error;
-use sticker::{SentenceDecoder, Tag};
+use sticker::{SentenceDecoder, SentenceTopKDecoder, Tag};
 
 // Wrap the sentence processing in a data type. This has the benefit that
 // we can use a destructor to write the last (possibly incomplete) batch.
@@ -11,11 +9,11 @@ pub struct SentProcessor<'a, D, T, W>
 where
     D: SentenceDecoder,
     T: Tag<D::Encoding>,
-    W: Write,
+    W: WriteSentence,
 {
     decoder: D,
     tagger: &'a T,
-    writer: Writer<W>,
+    writer: W,
     batch_size: usize,
     read_ahead: usize,
     buffer: Vec<Sentence>,
@@ -25,15 +23,9 @@ impl<'a, D, T, W> SentProcessor<'a, D, T, W>
 where
     D: SentenceDecoder,
     T: Tag<D::Encoding>,
-    W: Write,
+    W: WriteSentence,
 {
-    pub fn new(
-        decoder: D,
-        tagger: &'a T,
-        writer: Writer<W>,
-        batch_size: usize,
-        read_ahead: usize,
-    ) -> Self {
+    pub fn new(decoder: D, tagger: &'a T, writer: W, batch_size: usize, read_ahead: usize) -> Self {
         assert!(batch_size > 0, "Batch size should at least be 1.");
         assert!(read_ahead > 0, "Read ahead should at least be 1.");
 
@@ -84,12 +76,9 @@ where
     ) -> Result<(), Error>
     where
         D: SentenceDecoder,
-        W: Write,
     {
         for (sentence, sent_labels) in sentences.iter_mut().zip(labels) {
-            {
-                decoder.decode(sent_labels.as_slice(), sentence)?;
-            }
+            decoder.decode(sent_labels.as_slice(), sentence)?;
         }
 
         Ok(())
@@ -100,7 +89,108 @@ impl<'a, D, T, W> Drop for SentProcessor<'a, D, T, W>
 where
     D: SentenceDecoder,
     T: Tag<D::Encoding>,
-    W: Write,
+    W: WriteSentence,
+{
+    fn drop(&mut self) {
+        if !self.buffer.is_empty() {
+            if let Err(err) = self.tag_buffered_sentences() {
+                eprintln!("Error tagging sentences: {}", err);
+            }
+        }
+    }
+}
+
+// Wrap the sentence processing in a data type. This has the benefit that
+// we can use a destructor to write the last (possibly incomplete) batch.
+pub struct SentTopKProcessor<'a, D, T, W>
+where
+    D: SentenceTopKDecoder,
+    T: Tag<D::Encoding>,
+    W: WriteSentence,
+{
+    decoder: D,
+    tagger: &'a T,
+    writer: W,
+    batch_size: usize,
+    read_ahead: usize,
+    buffer: Vec<Sentence>,
+}
+
+impl<'a, D, T, W> SentTopKProcessor<'a, D, T, W>
+where
+    D: SentenceTopKDecoder,
+    T: Tag<D::Encoding>,
+    W: WriteSentence,
+{
+    pub fn new(decoder: D, tagger: &'a T, writer: W, batch_size: usize, read_ahead: usize) -> Self {
+        assert!(batch_size > 0, "Batch size should at least be 1.");
+        assert!(read_ahead > 0, "Read ahead should at least be 1.");
+
+        SentTopKProcessor {
+            decoder,
+            tagger,
+            writer,
+            batch_size,
+            read_ahead,
+            buffer: Vec::new(),
+        }
+    }
+
+    pub fn process(&mut self, sent: Sentence) -> Result<(), Error> {
+        self.buffer.push(sent);
+
+        if self.buffer.len() == self.batch_size * self.read_ahead {
+            self.tag_buffered_sentences()?;
+        }
+
+        Ok(())
+    }
+
+    fn tag_buffered_sentences(&mut self) -> Result<(), Error> {
+        // Sort sentences by length.
+        let mut sent_refs: Vec<_> = self.buffer.iter_mut().map(|s| s).collect();
+        sent_refs.sort_unstable_by_key(|s| s.len());
+
+        // Split in batches, tag, and merge results.
+        for batch in sent_refs.chunks_mut(self.batch_size) {
+            Self::merge_labels(
+                &self.decoder,
+                batch,
+                self.tagger.tag_sentences_top_k(batch)?,
+            )?;
+        }
+
+        // Write out sentences.
+        let mut sents = Vec::new();
+        std::mem::swap(&mut sents, &mut self.buffer);
+        for sent in sents {
+            self.writer.write_sentence(&sent)?;
+        }
+
+        Ok(())
+    }
+
+    fn merge_labels(
+        decoder: &D,
+        sentences: &mut [&mut Sentence],
+        labels: Vec<Vec<Vec<&D::Encoding>>>,
+    ) -> Result<(), Error>
+    where
+        D: SentenceTopKDecoder,
+    {
+        for (sentence, sent_labels) in sentences.iter_mut().zip(labels) {
+            decoder.decode_top_k(sent_labels.as_slice(), sentence)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a, D, T, W> Drop for SentTopKProcessor<'a, D, T, W>
+where
+    D: SentenceTopKDecoder,
+    T: Tag<D::Encoding>,
+    W: WriteSentence,
 {
     fn drop(&mut self) {
         if !self.buffer.is_empty() {

--- a/sticker-utils/src/serialization.rs
+++ b/sticker-utils/src/serialization.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 
 use failure::Error;
+use sticker::depparse::{DependencyEncoding, RelativePOS, RelativePosition};
 use sticker::Numberer;
 
 use serde_cbor;
@@ -26,10 +27,11 @@ impl TomlRead for Config {
     }
 }
 
-pub trait CborRead {
-    type Value;
-
-    fn from_cbor_read<R>(read: R) -> Result<Self::Value, Error>
+pub trait CborRead
+where
+    Self: Sized,
+{
+    fn from_cbor_read<R>(read: R) -> Result<Self, Error>
     where
         R: Read;
 }
@@ -37,19 +39,19 @@ pub trait CborRead {
 macro_rules! cbor_read {
     ($type: ty) => {
         impl CborRead for $type {
-            type Value = $type;
-
-            fn from_cbor_read<R>(read: R) -> Result<$type, Error>
+            fn from_cbor_read<R>(read: R) -> Result<Self, Error>
             where
                 R: Read,
             {
-                let system = serde_cbor::from_reader(read)?;
-                Ok(system)
+                let labels = serde_cbor::from_reader(read)?;
+                Ok(labels)
             }
         }
     };
 }
 
+cbor_read!(Numberer<DependencyEncoding<RelativePOS>>);
+cbor_read!(Numberer<DependencyEncoding<RelativePosition>>);
 cbor_read!(Numberer<String>);
 
 pub trait CborWrite {
@@ -87,4 +89,6 @@ macro_rules! cbor_write {
     };
 }
 
+cbor_write!(Numberer<DependencyEncoding<RelativePOS>>);
+cbor_write!(Numberer<DependencyEncoding<RelativePosition>>);
 cbor_write!(Numberer<String>);

--- a/sticker-utils/testdata/sticker.conf
+++ b/sticker-utils/testdata/sticker.conf
@@ -1,5 +1,5 @@
 [labeler]
-  layer = { feature = "tf" }
+  labeler_type = { sequence = { feature = "tf" } }
   labels = "sticker.labels"
   read_ahead = 10
 

--- a/sticker/src/encoder.rs
+++ b/sticker/src/encoder.rs
@@ -46,6 +46,7 @@ pub trait SentenceEncoder {
 }
 
 /// Encode sentences using a CoNLL-X layer.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LayerEncoder {
     layer: Layer,
 }


### PR DESCRIPTION
For `sticker-prepare` and `sticker-train`, this is pretty straightforward: change from concrete types to `SentenceEncoder` and `SentenceEncoder::Encoding`. The changes to `sticker-tag` and `sticker-server` (and thus `sent_proc`) are a bit uglier. For the parser decoders, we need top-k results, whereas for layer decoding we only need the best results.

I considered using top-k results everywhere and just using the first results for the layer decoder. But this probably adds some unnecessary overhead, since it requires that a `Vec` needs to be constructed for every token.

I also tried to abstract the decoder interface completely to support both a slice of encodings or a slice of a slice of encodings. But this resulted in ugly abstractionitis.

Any opinions? I am for either this code duplication or returning top-k results everywhere, but not in favor of the abstractionitis approach.