### PR TITLE
Support parsing in all the utilities

### DIFF
--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -5,12 +5,12 @@ use ordered_float::NotNan;
 use sticker::tensorflow::{ModelConfig, OpNames};
 use sticker::Layer;
 
-use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, TomlRead, Train};
+use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead, Train};
 
 lazy_static! {
     static ref BASIC_LABELER_CHECK: Config = Config {
         labeler: Labeler {
-            layer: Layer::Feature("tf".to_string()),
+            labeler_type: LabelerType::Sequence(Layer::Feature("tf".to_string())),
             labels: "sticker.labels".to_owned(),
             read_ahead: 10,
         },
@@ -42,7 +42,6 @@ lazy_static! {
                 labels_op: "prediction/model/labels".to_owned(),
                 inputs_op: "prediction/model/inputs".to_owned(),
                 seq_lens_op: "prediction/model/seq_lens".to_owned(),
-                predicted_op: "prediction/model/predicted".to_owned(),
                 top_k_predicted_op: "prediction/model/top_k_predicted".to_owned(),
                 accuracy_op: "prediction/model/accuracy".to_owned(),
                 loss_op: "prediction/model/loss".to_owned(),

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -1,5 +1,7 @@
 mod config;
-pub use crate::config::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, Train};
+pub use crate::config::{
+    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Labeler, LabelerType, Train,
+};
 
 mod progress;
 pub use crate::progress::FileProgress;

--- a/sticker-utils/src/serialization.rs
+++ b/sticker-utils/src/serialization.rs
@@ -1,6 +1,7 @@
 use std::io::{Read, Write};
 
 use failure::Error;
+use sticker::depparse::{DependencyEncoding, RelativePOS, RelativePosition};
 use sticker::Numberer;
 
 use serde_cbor;
@@ -26,10 +27,11 @@ impl TomlRead for Config {
     }
 }
 
-pub trait CborRead {
-    type Value;
-
-    fn from_cbor_read<R>(read: R) -> Result<Self::Value, Error>
+pub trait CborRead
+where
+    Self: Sized,
+{
+    fn from_cbor_read<R>(read: R) -> Result<Self, Error>
     where
         R: Read;
 }
@@ -37,19 +39,19 @@ pub trait CborRead {
 macro_rules! cbor_read {
     ($type: ty) => {
         impl CborRead for $type {
-            type Value = $type;
-
-            fn from_cbor_read<R>(read: R) -> Result<$type, Error>
+            fn from_cbor_read<R>(read: R) -> Result<Self, Error>
             where
                 R: Read,
             {
-                let system = serde_cbor::from_reader(read)?;
-                Ok(system)
+                let labels = serde_cbor::from_reader(read)?;
+                Ok(labels)
             }
         }
     };
 }
 
+cbor_read!(Numberer<DependencyEncoding<RelativePOS>>);
+cbor_read!(Numberer<DependencyEncoding<RelativePosition>>);
 cbor_read!(Numberer<String>);
 
 pub trait CborWrite {
@@ -87,4 +89,6 @@ macro_rules! cbor_write {
     };
 }
 
+cbor_write!(Numberer<DependencyEncoding<RelativePOS>>);
+cbor_write!(Numberer<DependencyEncoding<RelativePosition>>);
 cbor_write!(Numberer<String>);

--- a/sticker-utils/tensorflow/conv_model.py
+++ b/sticker-utils/tensorflow/conv_model.py
@@ -189,7 +189,7 @@ class ConvModel(Model):
         if config.crf:
             loss, transitions = self.crf_loss(
                 "tag", logits, self.tags)
-            predictions = self.crf_predictions(
+            predictions, top_k_predictions = self.crf_predictions(
                 "tag", logits, transitions)
         else:
             loss = self.masked_softmax_loss(

--- a/sticker-utils/tensorflow/model.py
+++ b/sticker-utils/tensorflow/model.py
@@ -56,7 +56,10 @@ class Model:
     def crf_predictions(self, prefix, logits, transitions):
         predictions, _ = tf.contrib.crf.crf_decode(
             logits, transitions, self.seq_lens)
-        return tf.identity(predictions, name="%s_predictions" % prefix)
+        top_k_predictions = tf.expand_dims(predictions, 2)
+        return predictions, tf.identity(
+            top_k_predictions, name="%s_top_k_predictions" %
+            prefix)
 
     def predictions(self, prefix, logits):
         # Get the best label, excluding padding.

--- a/sticker-utils/tensorflow/rnn_model.py
+++ b/sticker-utils/tensorflow/rnn_model.py
@@ -84,7 +84,7 @@ class RNNModel(Model):
         if config.crf:
             loss, transitions = self.crf_loss(
                 "tag", logits, self.tags)
-            predictions = self.crf_predictions(
+            predictions, top_k_predictions = self.crf_predictions(
                 "tag", logits, transitions)
         else:
             loss = self.masked_softmax_loss(

--- a/sticker-utils/testdata/sticker.conf
+++ b/sticker-utils/testdata/sticker.conf
@@ -1,5 +1,5 @@
 [labeler]
-  layer = { feature = "tf" }
+  labeler_type = { sequence = { feature = "tf" } }
   labels = "sticker.labels"
   read_ahead = 10
 
@@ -31,7 +31,6 @@
   inputs_op = "prediction/model/inputs"
   tags_op = "prediction/model/tags"
   seq_lens_op = "prediction/model/seq_lens"
-  predicted_op = "prediction/model/predicted"
   top_k_predicted_op = "prediction/model/top_k_predicted"
   accuracy_op = "prediction/model/accuracy"
   loss_op = "prediction/model/loss"

--- a/sticker/src/depparse/mod.rs
+++ b/sticker/src/depparse/mod.rs
@@ -63,7 +63,12 @@ mod tests {
             let sentence = sentence.unwrap();
 
             // Encode
-            let encodings = encoder_decoder.encode(&sentence).unwrap();
+            let encodings = encoder_decoder
+                .encode(&sentence)
+                .unwrap()
+                .into_iter()
+                .map(|e| [e])
+                .collect::<Vec<_>>();
 
             // Decode
             let mut test_sentence = copy_sentence_without_deprels(&sentence);

--- a/sticker/src/encoder.rs
+++ b/sticker/src/encoder.rs
@@ -12,23 +12,7 @@ use crate::{Layer, LayerValue};
 pub trait SentenceDecoder {
     type Encoding;
 
-    fn decode<E>(&self, labels: &[E], sentence: &mut Sentence) -> Result<(), Error>
-    where
-        E: Borrow<Self::Encoding>;
-}
-
-/// Trait for top-k sentence decoders.
-///
-/// A sentence decoder adds a representation to each token in a
-/// sentence, such as a part-of-speech tag or a topological field.
-///
-/// In contrast to a `SentenceDecoder`, a `SentenceTopKDecoder`
-/// is provided with multiple possible encodings. When an encoding
-/// is not applicable, the decoder can try the next encoding.
-pub trait SentenceTopKDecoder {
-    type Encoding;
-
-    fn decode_top_k<S, E>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    fn decode<S, E>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
     where
         E: Borrow<Self::Encoding>,
         S: AsRef<[E]>;
@@ -46,6 +30,7 @@ pub trait SentenceEncoder {
 }
 
 /// Encode sentences using a CoNLL-X layer.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LayerEncoder {
     layer: Layer,
 }
@@ -60,9 +45,10 @@ impl LayerEncoder {
 impl SentenceDecoder for LayerEncoder {
     type Encoding = String;
 
-    fn decode<E>(&self, labels: &[E], sentence: &mut Sentence) -> Result<(), Error>
+    fn decode<S, E>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
     where
         E: Borrow<Self::Encoding>,
+        S: AsRef<[E]>,
     {
         assert_eq!(
             labels.len(),
@@ -70,12 +56,14 @@ impl SentenceDecoder for LayerEncoder {
             "Labels and sentence length mismatch"
         );
 
-        for (token, label) in sentence
+        for (token, token_labels) in sentence
             .iter_mut()
             .filter_map(Node::token_mut)
             .zip(labels.iter())
         {
-            token.set_value(&self.layer, label.borrow().as_str());
+            if let Some(label) = token_labels.as_ref().get(0) {
+                token.set_value(&self.layer, label.borrow().as_str());
+            }
         }
 
         Ok(())

--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -2,7 +2,7 @@ mod collector;
 pub use crate::collector::{Collector, NoopCollector};
 
 mod encoder;
-pub use crate::encoder::{LayerEncoder, SentenceDecoder, SentenceEncoder, SentenceTopKDecoder};
+pub use crate::encoder::{LayerEncoder, SentenceDecoder, SentenceEncoder};
 
 pub mod depparse;
 

--- a/sticker/src/tag.rs
+++ b/sticker/src/tag.rs
@@ -63,9 +63,7 @@ impl LayerValue for Token {
 
 /// Trait for sequence taggers.
 pub trait Tag<T> {
-    fn tag_sentences(&self, sentences: &[impl Borrow<Sentence>]) -> Result<Vec<Vec<&T>>, Error>;
-
-    fn tag_sentences_top_k(
+    fn tag_sentences(
         &self,
         sentences: &[impl Borrow<Sentence>],
     ) -> Result<Vec<Vec<Vec<&T>>>, Error>;


### PR DESCRIPTION
To simplify the implementation, the SentenceTopKDecoder trait is
renamed to SentenceDecoder. The old SentenceDecoder is removed.

This is the alternative solution mentioned in #11. It does remove quite some code ;).