### PR TITLE
Actually create multiple RNN layers when requested

### DIFF
--- a/sticker-utils/tensorflow/config.py
+++ b/sticker-utils/tensorflow/config.py
@@ -10,7 +10,7 @@ class DefaultConfig:
     keep_prob_input = 0.80
     kernel_size = 3
     n_levels = 7
-    rnn_layers = 1
+    rnn_layers = 2
     top_k = 3
 
 

--- a/sticker-utils/tensorflow/write-graph
+++ b/sticker-utils/tensorflow/write-graph
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         "--rnn_layers",
         type=int,
         help="stacked RNN layers",
-        default=1)
+        default=2)
     parser.add_argument(
         "--top_k",
         type=int,


### PR DESCRIPTION
Also:

- Ditch the unidirectional RNN that was always applied.
- Instead, default to two bidirectional RNN layers.

These changes make the defaults more in line with most literature on
bidi RNN sequence labeling.