### PR TITLE
Hardcode Tensorflow op names

### DIFF
--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use lazy_static::lazy_static;
 use ordered_float::NotNan;
-use sticker::tensorflow::{ModelConfig, OpNames};
+use sticker::tensorflow::ModelConfig;
 use sticker::Layer;
 
 use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead, Train};
@@ -36,21 +36,6 @@ lazy_static! {
             parameters: "sticker.model".to_owned(),
             intra_op_parallelism_threads: 4,
             inter_op_parallelism_threads: 4,
-            op_names: OpNames {
-                is_training_op: "prediction/model/is_training".to_owned(),
-                init_op: "prediction/model/init".to_owned(),
-                labels_op: "prediction/model/labels".to_owned(),
-                inputs_op: "prediction/model/inputs".to_owned(),
-                seq_lens_op: "prediction/model/seq_lens".to_owned(),
-                top_k_predicted_op: "prediction/model/top_k_predicted".to_owned(),
-                accuracy_op: "prediction/model/accuracy".to_owned(),
-                loss_op: "prediction/model/loss".to_owned(),
-                lr_op: "prediction/model/lr".to_owned(),
-                save_op: "prediction/model/save".to_owned(),
-                save_path_op: "prediction/model/save_path".to_owned(),
-                restore_op: "prediction/model/restore".to_owned(),
-                train_op: "prediction/model/train".to_owned(),
-            },
         }
     };
 }

--- a/sticker-utils/testdata/sticker.conf
+++ b/sticker-utils/testdata/sticker.conf
@@ -23,19 +23,3 @@
   batch_size = 128
   intra_op_parallelism_threads=4
   inter_op_parallelism_threads=4
-
-  [model.op_names]
-  is_training_op = "prediction/model/is_training"
-  init_op = "prediction/model/init"
-  labels_op = "prediction/model/labels"
-  inputs_op = "prediction/model/inputs"
-  tags_op = "prediction/model/tags"
-  seq_lens_op = "prediction/model/seq_lens"
-  top_k_predicted_op = "prediction/model/top_k_predicted"
-  accuracy_op = "prediction/model/accuracy"
-  loss_op = "prediction/model/loss"
-  lr_op = "prediction/model/lr"
-  save_op = "prediction/model/save"
-  save_path_op = "prediction/model/save_path"
-  restore_op = "prediction/model/restore"
-  train_op = "prediction/model/train"

--- a/sticker/src/tensorflow/mod.rs
+++ b/sticker/src/tensorflow/mod.rs
@@ -7,6 +7,6 @@ pub use self::lr::{
 };
 
 mod tagger;
-pub use self::tagger::{ModelConfig, OpNames, Tagger, TaggerGraph};
+pub use self::tagger::{ModelConfig, Tagger, TaggerGraph};
 
 mod tensor;


### PR DESCRIPTION
At some point, op names were added to the sticker configuration to
allow customization. However, in practice, they are an annoyance ---
if ops are renamed or added, all existing configurations break. So
switch back to hardcoding the op names.