### PR TITLE
Correctly display validation loss.

### DIFF
--- a/sticker-utils/src/bin/sticker-train.rs
+++ b/sticker-utils/src/bin/sticker-train.rs
@@ -125,7 +125,7 @@ where
             epoch, lr, loss, acc
         );
 
-        let (_, acc) = run_epoch(&tagger, &validation_tensors, false, lr);
+        let (loss, acc) = run_epoch(&tagger, &validation_tensors, false, lr);
 
         last_acc = acc;
         if acc > best_acc {


### PR DESCRIPTION
Previously, the train loss was displayed as validation loss.

Addresses #29