### PR TITLE
Split Tagger into Tagger and Trainer data structures

### DIFF
--- a/sticker/src/tensorflow/mod.rs
+++ b/sticker/src/tensorflow/mod.rs
@@ -7,6 +7,6 @@ pub use self::lr::{
 };
 
 mod tagger;
-pub use self::tagger::{ModelConfig, Tagger, TaggerGraph};
+pub use self::tagger::{ModelConfig, Tagger, TaggerGraph, TaggerTrainer};
 
 mod tensor;


### PR DESCRIPTION
This reduces the dependency burden for training uses, since no labels
and vectorizer are needed.