### PR TITLE
Introduce CategoricalEncoder

### DIFF
--- a/sticker-utils/src/bin/sticker-dep2label.rs
+++ b/sticker-utils/src/bin/sticker-dep2label.rs
@@ -64,7 +64,7 @@ fn main() {
     }
 }
 
-fn label_with_encoder<E, R, W>(encoder: E, read: R, mut write: W)
+fn label_with_encoder<E, R, W>(mut encoder: E, read: R, mut write: W)
 where
     E: SentenceEncoder,
     E::Encoding: ToString,

--- a/sticker-utils/src/bin/sticker-tag.rs
+++ b/sticker-utils/src/bin/sticker-tag.rs
@@ -10,7 +10,7 @@ use stdinout::{Input, OrExit, Output};
 
 use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{Tagger, TaggerGraph};
-use sticker::{LayerEncoder, Numberer, SentVectorizer, SentenceDecoder};
+use sticker::{CategoricalEncoder, LayerEncoder, Numberer, SentVectorizer, SentenceDecoder};
 use sticker_utils::{CborRead, Config, EncoderType, LabelerType, SentProcessor, TomlRead};
 
 fn print_usage(program: &str, opts: Options) {
@@ -117,11 +117,17 @@ fn process_with_decoder<D, R, W>(
         1,
     );
 
-    let tagger = Tagger::load_weights(graph, labels, vectorizer, &config.model.parameters)
-        .or_exit("Cannot construct tagger", 1);
+    let categorical_decoder = CategoricalEncoder::new(decoder, labels);
+
+    let tagger = Tagger::load_weights(
+        graph,
+        categorical_decoder,
+        vectorizer,
+        &config.model.parameters,
+    )
+    .or_exit("Cannot construct tagger", 1);
 
     let mut sent_proc = SentProcessor::new(
-        decoder,
         &tagger,
         write,
         config.model.batch_size,

--- a/sticker-utils/src/bin/sticker-train.rs
+++ b/sticker-utils/src/bin/sticker-train.rs
@@ -14,7 +14,9 @@ use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{
     CollectedTensors, LearningRateSchedule, TaggerGraph, TaggerTrainer, TensorCollector,
 };
-use sticker::{Collector, LayerEncoder, Numberer, SentVectorizer, SentenceEncoder};
+use sticker::{
+    CategoricalEncoder, Collector, LayerEncoder, Numberer, SentVectorizer, SentenceEncoder,
+};
 use sticker_utils::{CborRead, Config, EncoderType, LabelerType, ReadProgress, TomlRead};
 
 fn print_usage(program: &str, opts: Options) {
@@ -203,6 +205,8 @@ where
         1,
     );
 
+    let encoder = CategoricalEncoder::new(encoder, labels);
+
     let input_file = File::open(path.as_ref()).or_exit(
         format!(
             "Cannot open '{}' for reading",
@@ -214,7 +218,7 @@ where
         ReadProgress::new(input_file).or_exit("Cannot create file progress bar", 1),
     ));
 
-    let mut collector = TensorCollector::new(config.model.batch_size, encoder, labels, vectorizer);
+    let mut collector = TensorCollector::new(config.model.batch_size, encoder, vectorizer);
     for sentence in reader.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);
         collector

--- a/sticker/src/depparse/mod.rs
+++ b/sticker/src/depparse/mod.rs
@@ -54,7 +54,7 @@ mod tests {
         copy
     }
 
-    fn test_encoding<P, E, C>(path: P, encoder_decoder: E)
+    fn test_encoding<P, E, C>(path: P, mut encoder_decoder: E)
     where
         P: AsRef<Path>,
         E: SentenceEncoder<Encoding = C> + SentenceDecoder<Encoding = C>,

--- a/sticker/src/depparse/relative_pos.rs
+++ b/sticker/src/depparse/relative_pos.rs
@@ -137,7 +137,7 @@ impl RelativePOSEncoder {
 impl SentenceEncoder for RelativePOSEncoder {
     type Encoding = DependencyEncoding<RelativePOS>;
 
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+    fn encode(&mut self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
         let pos_table = pos_position_table(&sentence);
 
         let mut encoded = Vec::with_capacity(sentence.len());

--- a/sticker/src/depparse/relative_position.rs
+++ b/sticker/src/depparse/relative_position.rs
@@ -54,7 +54,7 @@ impl RelativePositionEncoder {
 impl SentenceEncoder for RelativePositionEncoder {
     type Encoding = DependencyEncoding<RelativePosition>;
 
-    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+    fn encode(&mut self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
         let mut encoded = Vec::with_capacity(sentence.len());
         for idx in 0..sentence.len() {
             let token = &sentence[idx];

--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -2,7 +2,9 @@ mod collector;
 pub use crate::collector::{Collector, NoopCollector};
 
 mod encoder;
-pub use crate::encoder::{EncodingProb, LayerEncoder, SentenceDecoder, SentenceEncoder};
+pub use crate::encoder::{
+    CategoricalEncoder, EncodingProb, LayerEncoder, SentenceDecoder, SentenceEncoder,
+};
 
 pub mod depparse;
 

--- a/sticker/src/tag.rs
+++ b/sticker/src/tag.rs
@@ -1,11 +1,9 @@
-use std::borrow::Borrow;
+use std::borrow::BorrowMut;
 
 use conllx::graph::Sentence;
 use conllx::token::{Features, Token};
-use failure::Error;
+use failure::Fallible;
 use serde_derive::{Deserialize, Serialize};
-
-use crate::EncodingProb;
 
 /// Tagging layer.
 #[serde(rename_all = "lowercase")]
@@ -64,14 +62,8 @@ impl LayerValue for Token {
 }
 
 /// Trait for sequence taggers.
-pub trait Tag<T>
-where
-    T: ToOwned,
-{
-    fn tag_sentences(
-        &self,
-        sentences: &[impl Borrow<Sentence>],
-    ) -> Result<Vec<Vec<Vec<EncodingProb<T>>>>, Error>;
+pub trait Tag {
+    fn tag_sentences(&self, sentences: &mut [impl BorrowMut<Sentence>]) -> Fallible<()>;
 }
 
 /// Results of validation.


### PR DESCRIPTION
This is a wrapper around a Sentence{Encoder,Decoder} and Numberer,
that directly encoder from/to usize categorical labels.

---

The motivation for this change was that we carry around encoders and labelers together, since they are typically used together: encode and map to numbers, map numbers to encodings and decode. So why not put them together. `CategoricalEncoder` wraps any encoder/decoder to directly go to/from numbers.

`CategoricalEncoder` is now also used directly in `Tagger`, avoiding the need to allocate the full intermediate `Vec<Vec<Vec<_>>>` of encodings with their probabilities.