### PR TITLE
Configure learning rate schedule with sticker-train options

### DIFF
--- a/sticker-utils/src/config.rs
+++ b/sticker-utils/src/config.rs
@@ -6,10 +6,9 @@ use std::path::Path;
 use failure::{format_err, Error};
 use finalfusion::embeddings::Embeddings as FiFuEmbeddings;
 use finalfusion::prelude::*;
-use ordered_float::NotNan;
 use serde_derive::{Deserialize, Serialize};
 
-use sticker::tensorflow::{ModelConfig, PlateauLearningRate};
+use sticker::tensorflow::ModelConfig;
 use sticker::{Layer, LayerEmbeddings, Numberer};
 
 use crate::CborRead;
@@ -19,7 +18,6 @@ pub struct Config {
     pub labeler: Labeler,
     pub embeddings: Embeddings,
     pub model: ModelConfig,
-    pub train: Train,
 }
 
 impl Config {
@@ -154,22 +152,4 @@ fn relativize_path(config_path: &Path, filename: &str) -> Result<String, Error> 
             )
         })?
         .to_owned())
-}
-
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
-pub struct Train {
-    pub initial_lr: NotNan<f32>,
-    pub lr_scale: NotNan<f32>,
-    pub lr_patience: usize,
-    pub patience: usize,
-}
-
-impl Train {
-    pub fn lr_schedule(&self) -> PlateauLearningRate {
-        PlateauLearningRate::new(
-            self.initial_lr.into_inner(),
-            self.lr_scale.into_inner(),
-            self.lr_patience,
-        )
-    }
 }

--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -1,11 +1,10 @@
 use std::fs::File;
 
 use lazy_static::lazy_static;
-use ordered_float::NotNan;
 use sticker::tensorflow::ModelConfig;
 use sticker::Layer;
 
-use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead, Train};
+use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead};
 
 lazy_static! {
     static ref BASIC_LABELER_CHECK: Config = Config {
@@ -23,12 +22,6 @@ lazy_static! {
                 filename: "tag-vectors.bin".into(),
                 alloc: EmbeddingAlloc::Read,
             }),
-        },
-        train: Train {
-            initial_lr: NotNan::from(0.05),
-            lr_scale: NotNan::from(0.5),
-            lr_patience: 4,
-            patience: 10,
         },
         model: ModelConfig {
             batch_size: 128,

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -3,7 +3,7 @@ pub use crate::app::sticker_app;
 
 mod config;
 pub use crate::config::{
-    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Labeler, LabelerType, Train,
+    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Labeler, LabelerType,
 };
 
 mod progress;

--- a/sticker-utils/testdata/sticker.conf
+++ b/sticker-utils/testdata/sticker.conf
@@ -11,12 +11,6 @@
   filename = "tag-vectors.bin"
   alloc = "read"
 
-[train]
-  initial_lr = 0.05
-  lr_scale = 0.5
-  lr_patience = 4
-  patience = 10
-
 [model]
   graph = "sticker.graph"
   parameters = "sticker.model"


### PR DESCRIPTION
This moves the learning rate settings out of the configuration file.

This is also the last larger planned change before branching release-0.3.