### PR TITLE
Deny unknown fields in configuration files

### DIFF
--- a/sticker-utils/src/config.rs
+++ b/sticker-utils/src/config.rs
@@ -14,6 +14,7 @@ use sticker::{Layer, LayerEmbeddings, Numberer};
 use crate::CborRead;
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub labeler: Labeler,
     pub embeddings: Embeddings,
@@ -42,12 +43,14 @@ impl Config {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Embeddings {
     pub word: Embedding,
     pub tag: Option<Embedding>,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Embedding {
     pub filename: String,
     pub alloc: EmbeddingAlloc,
@@ -92,6 +95,7 @@ pub enum EncoderType {
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Labeler {
     pub labels: String,
     pub read_ahead: usize,

--- a/sticker/src/tensorflow/tagger.rs
+++ b/sticker/src/tensorflow/tagger.rs
@@ -23,6 +23,7 @@ use crate::encoder::{CategoricalEncoder, SentenceDecoder};
 use crate::{EncodingProb, ModelPerformance, SentVectorizer, Tag};
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct ModelConfig {
     /// Model batch size, should be kept constant between training and
     /// prediction.


### PR DESCRIPTION
My config files have accumulated quite some unused configuration options since the beginning of toponn/sticker. Besides failing on missing options, we should also fail on non-existing options. Keeps all the configuration files clean ;).