### PR TITLE
Adds the summary writer in write_helper.

### DIFF
--- a/sticker-graph/sticker_graph/write_helper.py
+++ b/sticker-graph/sticker_graph/write_helper.py
@@ -11,6 +11,35 @@ def read_shapes(args):
     return shapes
 
 
+def _create_file_writer_generic_type(logdir,
+                                    name="logdir",
+                                    max_queue=None,
+                                    flush_millis=None,
+                                    filename_suffix=None):
+    """
+    This method mirrors `tensorflow.contrib.summary.create_file_writer`. Unlike
+    `summary.create_file_writer`, this method accepts a placeholder as `logdir`.
+    """
+    from tensorflow.python.ops.summary_ops_v2 import _make_summary_writer
+    from tensorflow.python.ops.gen_summary_ops import create_summary_file_writer
+
+    logdir = tf.convert_to_tensor(logdir)
+    with tf.device("cpu:0"):
+        if max_queue is None:
+            max_queue = tf.constant(10)
+        if flush_millis is None:
+            flush_millis = tf.constant(2 * 60 * 1000)
+        if filename_suffix is None:
+            filename_suffix = tf.constant(".v2")
+        return _make_summary_writer(
+            name,
+            create_summary_file_writer,
+            logdir=logdir,
+            max_queue=max_queue,
+            flush_millis=flush_millis,
+            filename_suffix=filename_suffix)
+
+
 def create_graph(config, model, args):
     shapes = read_shapes(args)
     graph_filename = args.output_graph_file
@@ -19,18 +48,27 @@ def create_graph(config, model, args):
     tfconfig = tf.ConfigProto(gpu_options=gpuopts)
 
     with tf.Graph().as_default(), tf.Session(config=tfconfig) as session:
-        with tf.variable_scope("model", reuse=None):
-            model(config=config, shapes=shapes)
+        logdir = tf.placeholder(shape=[], name="logdir", dtype=tf.string)
+        summary_writer = _create_file_writer_generic_type(logdir)
 
-        tf.variables_initializer(tf.global_variables(), name='init')
+        with summary_writer.as_default(), tf.contrib.summary.always_record_summaries():
+            with tf.variable_scope("model", reuse=None):
+                model(config=config, shapes=shapes)
 
-        tf.train.Saver(tf.global_variables())
+            tf.group(tf.contrib.summary.summary_writer_initializer_op(),
+                     name="summary_init")
+            tf.variables_initializer(tf.global_variables(), name='init')
 
-        tf.train.write_graph(
-            session.graph_def,
-            './',
-            graph_filename,
-            as_text=False)
+            tf.train.Saver(tf.global_variables())
+
+            serialized_graph = session.graph_def.SerializeToString()
+            serialized_graph_tensor = tf.convert_to_tensor(serialized_graph)
+            tf.contrib.summary.graph(serialized_graph_tensor, 0, name='graph_write')
+            tf.train.write_graph(
+                session.graph_def,
+                './',
+                graph_filename,
+                as_text=False)
 
 
 def get_common_parser():


### PR DESCRIPTION
This is the first step towards integrating tensorboard summaries.

The `_create_file_writer_generic_type` method is necessary to define `logdir` per run, in contrast to per graph definition. This is useful when experimenting with learning rates or batch sizes. 

This PR should not have an impact besides adding the ops to the graph. The next PRs will add the actual summary ops and the necessary bits in `sticker-train`.