### PR TITLE
Adds Tensorboard summaries.

### DIFF
--- a/sticker-graph/sticker_graph/rnn_model.py
+++ b/sticker-graph/sticker_graph/rnn_model.py
@@ -102,8 +102,12 @@ class RNNModel(Model):
             predictions = self.predictions("tag", logits)
             self.top_k_predictions("tag", logits, config.top_k)
 
-        self.accuracy("tag", predictions, self.tags)
+        acc = self.accuracy("tag", predictions, self.tags)
 
         lr = tf.placeholder(tf.float32, [], "lr")
+
+        train_step = tf.train.get_or_create_global_step()
         self._train_op = tf.train.AdamOptimizer(
-            lr).minimize(loss, name="train")
+            lr).minimize(loss, name="train",global_step=train_step)
+
+        self.create_summary_ops(acc, None, loss, lr)

--- a/sticker-graph/sticker_graph/transformer_model.py
+++ b/sticker-graph/sticker_graph/transformer_model.py
@@ -299,13 +299,18 @@ class TransformerModel(Model):
             predictions = self.predictions("tag", logits)
             self.top_k_predictions("tag", logits, config.top_k)
 
-        self.accuracy("tag", predictions, self.tags)
+        acc = self.accuracy("tag", predictions, self.tags)
 
         # Optimization with gradient clipping. Consider making the gradient
         # norm a placeholder as well.
         lr = tf.placeholder(tf.float32, [], "lr")
+
         optimizer = tf.train.AdamOptimizer(lr)
         gradients, variables = zip(*optimizer.compute_gradients(loss))
-        gradients, gn = tf.clip_by_global_norm(gradients, 2.5)
+        gradients, gradient_norm = tf.clip_by_global_norm(gradients, 2.5)
+
+        train_step = tf.train.get_or_create_global_step()
         self._train_op = optimizer.apply_gradients(
-            zip(gradients, variables), name="train")
+            zip(gradients, variables), name="train", global_step=train_step)
+
+        self.create_summary_ops(acc, gradient_norm, loss, lr)

--- a/sticker/src/tensorflow/tagger.rs
+++ b/sticker/src/tensorflow/tagger.rs
@@ -77,11 +77,23 @@ mod op_names {
     pub const TOP_K_PROBS_OP: &str = "model/tag_top_k_probs";
 
     pub const TRAIN_OP: &str = "model/train";
+    pub const WRITE_GRAPH_OP: &str = "graph_write";
+    pub const LOGDIR_OP: &str = "logdir";
+    pub const SUMMARY_INIT_OP: &str = "summary_init";
+
+    pub const VAL_SUMMARIES_OP: &str = "model/summaries/val";
+    pub const TRAIN_SUMMARIES_OP: &str = "model/summaries/train";
 }
 
 pub struct TaggerGraph {
     pub(crate) graph: Graph,
     pub(crate) model_config: ModelConfig,
+
+    pub(crate) graph_write_op: Operation,
+    pub(crate) logdir_op: Operation,
+    pub(crate) summary_init_op: Operation,
+    pub(crate) train_summary_op: Operation,
+    pub(crate) val_summary_op: Operation,
 
     pub(crate) init_op: Operation,
     pub(crate) restore_op: Operation,
@@ -134,9 +146,23 @@ impl TaggerGraph {
 
         let train_op = Self::add_op(&graph, op_names::TRAIN_OP)?;
 
+        let graph_write_op = Self::add_op(&graph, op_names::WRITE_GRAPH_OP)?;
+        let logdir_op = Self::add_op(&graph, op_names::LOGDIR_OP)?;
+        let summary_init_op = Self::add_op(&graph, op_names::SUMMARY_INIT_OP)?;
+
+        let train_summary_op = Self::add_op(&graph, op_names::TRAIN_SUMMARIES_OP)?;
+        let val_summary_op = Self::add_op(&graph, op_names::VAL_SUMMARIES_OP)?;
+
         Ok(TaggerGraph {
             graph,
             model_config: model_config.clone(),
+
+            graph_write_op,
+            logdir_op,
+            summary_init_op,
+
+            train_summary_op,
+            val_summary_op,
 
             init_op,
             restore_op,


### PR DESCRIPTION
This PR adds a parameter --logdir to sticker-train.

If it is provided, summaries are written to that directory. The summaries entail accuracy, loss, learning rate, and if provided gradient norms.

For the RNN-model, no gradient norms are logged because no gradient clipping is performed. This may be something for later

Screenshot from some transformer training:

![tensorboard](https://user-images.githubusercontent.com/23434860/59131230-17cb7e80-8972-11e9-9e61-c674a9f67121.png)
_______________________________________________________

The PR got a bit bulkier than planned. Originally I had planned to first add the `init_logdir` method and the `--logdir` parameter and then in a separate PR the accuracy, loss, etc summaries, but for some reason, the graph is not written if no other summaries are added. If wanted, I can still split this PR into two, one for graph writing, the other to add the actual summaries. This one could then serve as a functional basis to see what the result would look like.



