### PR TITLE
sticker-{server,tag}: measure tagging speed

### DIFF
--- a/sticker-utils/src/bin/sticker-server.rs
+++ b/sticker-utils/src/bin/sticker-server.rs
@@ -13,7 +13,7 @@ use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{Tagger, TaggerGraph};
 use sticker::{CategoricalEncoder, LayerEncoder, Numberer, SentVectorizer, SentenceDecoder};
 use sticker_utils::{
-    sticker_app, CborRead, Config, EncoderType, LabelerType, SentProcessor, TomlRead,
+    sticker_app, CborRead, Config, EncoderType, LabelerType, SentProcessor, TaggerSpeed, TomlRead,
 };
 
 static CONFIG: &str = "CONFIG";
@@ -195,6 +195,8 @@ where
     let reader = Reader::new(BufReader::new(&conllx_stream));
     let writer = Writer::new(BufWriter::new(&conllx_stream));
 
+    let mut speed = TaggerSpeed::new();
+
     let mut sent_proc = SentProcessor::new(
         &*tagger,
         writer,
@@ -214,6 +216,8 @@ where
             let _ = writeln!(stream, "! Error processing sentence: {}", err);
             return;
         }
+
+        speed.count_sentence()
     }
 
     eprintln!("Finished processing for {}", peer_addr);

--- a/sticker-utils/src/bin/sticker-tag.rs
+++ b/sticker-utils/src/bin/sticker-tag.rs
@@ -10,7 +10,7 @@ use sticker::depparse::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::tensorflow::{Tagger, TaggerGraph};
 use sticker::{CategoricalEncoder, LayerEncoder, Numberer, SentVectorizer, SentenceDecoder};
 use sticker_utils::{
-    sticker_app, CborRead, Config, EncoderType, LabelerType, SentProcessor, TomlRead,
+    sticker_app, CborRead, Config, EncoderType, LabelerType, SentProcessor, TaggerSpeed, TomlRead,
 };
 
 static CONFIG: &str = "CONFIG";
@@ -141,6 +141,8 @@ fn process_with_decoder<D, R, W>(
     )
     .or_exit("Cannot construct tagger", 1);
 
+    let mut speed = TaggerSpeed::new();
+
     let mut sent_proc = SentProcessor::new(
         &tagger,
         write,
@@ -153,5 +155,7 @@ fn process_with_decoder<D, R, W>(
         sent_proc
             .process(sentence)
             .or_exit("Error processing sentence", 1);
+
+        speed.count_sentence()
     }
 }

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -7,7 +7,7 @@ pub use crate::config::{
 };
 
 mod progress;
-pub use crate::progress::ReadProgress;
+pub use crate::progress::{ReadProgress, TaggerSpeed};
 
 mod sent_proc;
 pub use crate::sent_proc::SentProcessor;


### PR DESCRIPTION
Prints a line to stderr with the tagging speed. For example:

~~~
Processed 9560 sentences in 22.3s (428.0 sents/s)
~~~