### PR TITLE
Add option for residual connections to the rnn.

### DIFF
--- a/sticker-graph/sticker-write-rnn-graph
+++ b/sticker-graph/sticker-write-rnn-graph
@@ -30,7 +30,12 @@ if __name__ == '__main__':
         type=float,
         help="input keep probability",
         default=0.80)
-
+    parser.add_argument(
+        "--residual",
+        action='store_true',
+        default=False,
+        help="Use residual skip connections between RNN layers."
+    )
     args = parser.parse_args()
 
     model = RNNModel

--- a/sticker-graph/sticker_graph/rnn_model.py
+++ b/sticker-graph/sticker_graph/rnn_model.py
@@ -1,7 +1,8 @@
 import tensorflow as tf
 from tensorflow.contrib.layers import batch_norm
-from sticker_graph.model import Model
 
+from sticker_graph.model import Model
+import sticker_graph.vendored
 
 def dropout_wrapper(
         cell,
@@ -30,7 +31,8 @@ def bidi_rnn_layers(
         output_keep_prob=1.0,
         state_keep_prob=1.0,
         seq_lens=None,
-        gru=False):
+        gru=False,
+        residual_connections=False):
     if gru:
         cell = tf.nn.rnn_cell.GRUCell
     else:
@@ -49,13 +51,13 @@ def bidi_rnn_layers(
             is_training=is_training,
             state_keep_prob=state_keep_prob,
             output_keep_prob=output_keep_prob) for i in range(num_layers)]
-
-    return tf.contrib.rnn.stack_bidirectional_dynamic_rnn(
+    return sticker_graph.vendored.stack_bidirectional_dynamic_rnn(
         fw_cells,
         bw_cells,
         inputs,
         dtype=tf.float32,
-        sequence_length=seq_lens)
+        sequence_length=seq_lens,
+        residual_connections=residual_connections)
 
 
 class RNNModel(Model):
@@ -79,7 +81,8 @@ class RNNModel(Model):
             output_size=args.hidden_size,
             output_keep_prob=args.keep_prob,
             seq_lens=self._seq_lens,
-            gru=args.gru)
+            gru=args.gru,
+            residual_connections=args.residual)
 
         hidden_states = batch_norm(
             hidden_states,

--- a/sticker-graph/sticker_graph/vendored.py
+++ b/sticker-graph/sticker_graph/vendored.py
@@ -1,0 +1,94 @@
+# Copyright 2015 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tensorflow as tf
+
+
+def stack_bidirectional_dynamic_rnn(cells_fw,
+                                    cells_bw,
+                                    inputs,
+                                    initial_states_fw=None,
+                                    initial_states_bw=None,
+                                    dtype=None,
+                                    sequence_length=None,
+                                    parallel_iterations=None,
+                                    time_major=False,
+                                    scope=None,
+                                    residual_connections=False):
+    """
+    NOTE:
+    This is a modified copy of tf.contrib.rnn.stack_bidirectional_dynamic_rnn
+    that adds the option to have residual skip connections. It has been taken
+    from https://github.com/tensorflow/tensorflow/blob/r1.13/tensorflow/contrib/rnn/python/ops/rnn.py.
+
+    If residual connections is True, the input of a layer is summed with the
+    output of the layer. In order to allow for inputs with other dimensionality
+    than that of the concatenated RNN states, the input to the first layer is
+    not summed to its output.
+    """
+    if not cells_fw:
+        raise ValueError("Must specify at least one fw cell for BidirectionalRNN.")
+    if not cells_bw:
+        raise ValueError("Must specify at least one bw cell for BidirectionalRNN.")
+    if not isinstance(cells_fw, list):
+        raise ValueError("cells_fw must be a list of RNNCells (one per layer).")
+    if not isinstance(cells_bw, list):
+        raise ValueError("cells_bw must be a list of RNNCells (one per layer).")
+    if len(cells_fw) != len(cells_bw):
+        raise ValueError("Forward and Backward cells must have the same depth.")
+    if (initial_states_fw is not None and
+            (not isinstance(initial_states_fw, list) or
+             len(initial_states_fw) != len(cells_fw))):
+        raise ValueError(
+            "initial_states_fw must be a list of state tensors (one per layer).")
+    if (initial_states_bw is not None and
+            (not isinstance(initial_states_bw, list) or
+             len(initial_states_bw) != len(cells_bw))):
+        raise ValueError(
+            "initial_states_bw must be a list of state tensors (one per layer).")
+
+    states_fw = []
+    states_bw = []
+    prev_layer = inputs
+
+    with tf.variable_scope(scope or "stack_bidirectional_rnn"):
+        for i, (cell_fw, cell_bw) in enumerate(zip(cells_fw, cells_bw)):
+            initial_state_fw = None
+            initial_state_bw = None
+            if initial_states_fw:
+                initial_state_fw = initial_states_fw[i]
+            if initial_states_bw:
+                initial_state_bw = initial_states_bw[i]
+
+            with tf.variable_scope("cell_%d" % i):
+                shortcut = prev_layer
+                outputs, (state_fw, state_bw) = tf.nn.bidirectional_dynamic_rnn(
+                    cell_fw,
+                    cell_bw,
+                    prev_layer,
+                    initial_state_fw=initial_state_fw,
+                    initial_state_bw=initial_state_bw,
+                    sequence_length=sequence_length,
+                    parallel_iterations=parallel_iterations,
+                    dtype=dtype,
+                    time_major=time_major)
+                # Concat the outputs to create the new input.
+                prev_layer = tf.concat(outputs, 2)
+                if i != 0 and residual_connections:
+                    prev_layer += shortcut
+
+            states_fw.append(state_fw)
+            states_bw.append(state_bw)
+
+    return prev_layer, tuple(states_fw), tuple(states_bw)


### PR DESCRIPTION
Adds `--residual` to `sticker-write-rnn-graph` which enables residual skip connections of the
rnn layers.
