### PR TITLE
Unify model-info for all variants.

### DIFF
--- a/sticker-graph/sticker-write-conv-graph
+++ b/sticker-graph/sticker-write-conv-graph
@@ -38,11 +38,4 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    model = ConvModel
-
-    print("Model: convolution, kernel: %d, levels: %d, glu: %r, crf: %r\n"
-          "Dropout input: %.2f, hidden: %.2f" %
-          (args.kernel_size, args.levels, not args.relu,
-           args.crf, args.keep_prob_input, args.keep_prob))
-
-    create_graph(model, args)
+    create_graph(ConvModel, args)

--- a/sticker-graph/sticker-write-rnn-graph
+++ b/sticker-graph/sticker-write-rnn-graph
@@ -38,11 +38,4 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    model = RNNModel
-
-    print("Model: rnn, gru: %r, crf: %r, layers: %d\n"
-          "Dropout input: %.2f, hidden: %.2f" %
-          (args.gru, args.crf, args.rnn_layers,
-           args.keep_prob_input, args.keep_prob))
-
-    create_graph(model, args)
+    create_graph(RNNModel, args)

--- a/sticker-graph/sticker-write-transformer-graph
+++ b/sticker-graph/sticker-write-transformer-graph
@@ -92,10 +92,4 @@ if __name__ == '__main__':
                      "outer_hsize: {} NUM_HEADS: {}"
                      .format(args.outer_hsize, args.num_heads))
     
-    model = TransformerModel
-
-    print("Model = Transformer",
-          toml.dumps(args.__dict__),
-          sep="\n")
-
-    create_graph(model, args)
+    create_graph(TransformerModel, args)

--- a/sticker-graph/sticker_graph/write_helper.py
+++ b/sticker-graph/sticker_graph/write_helper.py
@@ -11,6 +11,10 @@ def read_shapes(args):
 
 
 def create_graph(model, args):
+    print('Model = "{}"'.format(model.__name__),
+          toml.dumps(args.__dict__),
+          sep="\n")
+
     shapes = read_shapes(args)
     graph_filename = args.output_graph_file
 


### PR DESCRIPTION
This unifies the printed model info such that all are valid toml. It moves the printing code from the various scripts to write-helper.py.