### PR TITLE
Fix CRF support

### DIFF
--- a/sticker-graph/sticker_graph/model.py
+++ b/sticker-graph/sticker_graph/model.py
@@ -57,6 +57,11 @@ class Model:
         predictions, _ = tf.contrib.crf.crf_decode(
             logits, transitions, self.seq_lens)
         top_k_predictions = tf.expand_dims(predictions, 2)
+
+        # We don't get per-item probabilities, so just return ones.
+        top_k_probs = tf.ones(tf.shape(top_k_predictions), tf.float32,
+            name="%s_top_k_probs" % prefix)
+
         return predictions, tf.identity(
             top_k_predictions, name="%s_top_k_predictions" %
             prefix)


### PR DESCRIPTION
No op named 'tag_top_k_probs' was created when '--crf' was used. This change
adds this op to graphs with a CRF layer.

Since CRF decoding does not provide per-tag probabilities, use a probability
of 1 for each rag.

Fixes #99.