### PR TITLE
Add support for RNN-based subword representations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
       - ./sticker-write-rnn-graph --rnn_layers 2 --hidden_size 100 testdata/sticker.shapes rnn.graph
       - ./sticker-write-conv-graph --levels 6 --hidden_size 100 testdata/sticker.shapes conv.graph
       - ./sticker-write-transformer-graph testdata/sticker.shapes trans.graph
-      - ./sticker-write-transformer-graph --outer_hsize 350 --pass_inputs --num_heads 7 testdata/sticker.shapes trans-pass-input.graph
-      - ./sticker-write-transformer-graph --outer_hsize 350 --pass_inputs --num_heads 7 --embed_time --max_time 150 testdata/sticker.shapes trans-time.graph
+      - ./sticker-write-transformer-graph --outer_hsize 400 --pass_inputs --num_heads 8 testdata/sticker.shapes trans-pass-input.graph
+      - ./sticker-write-transformer-graph --outer_hsize 400 --pass_inputs --num_heads 8 --embed_time --max_time 150 testdata/sticker.shapes trans-time.graph
   - language: rust
     os: linux
     rust: 1.34.2

--- a/sticker-graph/sticker_graph/conv_model.py
+++ b/sticker-graph/sticker_graph/conv_model.py
@@ -162,13 +162,8 @@ class ConvModel(Model):
 
         self.setup_placeholders()
 
-        inputs = tf.contrib.layers.dropout(
-            self.inputs,
-            keep_prob=args.keep_prob_input,
-            is_training=self.is_training)
-
         hidden_states = dilated_convolution(
-            inputs,
+            self.inputs,
             args.hidden_size,
             kernel_size=args.kernel_size,
             n_levels=args.levels,

--- a/sticker-graph/sticker_graph/rnn.py
+++ b/sticker-graph/sticker_graph/rnn.py
@@ -1,0 +1,59 @@
+import tensorflow as tf
+
+import sticker_graph.vendored
+
+
+def dropout_wrapper(
+        cell,
+        is_training,
+        output_keep_prob=1.0,
+        state_keep_prob=1.0):
+    output_keep_prob = tf.cond(
+        is_training,
+        lambda: tf.constant(output_keep_prob),
+        lambda: tf.constant(1.0))
+    state_keep_prob = tf.cond(
+        is_training,
+        lambda: tf.constant(state_keep_prob),
+        lambda: tf.constant(1.0))
+    return tf.contrib.rnn.DropoutWrapper(
+        cell,
+        output_keep_prob=output_keep_prob,
+        state_keep_prob=state_keep_prob)
+
+
+def bidi_rnn_layers(
+        is_training,
+        inputs,
+        num_layers=1,
+        output_size=50,
+        output_keep_prob=1.0,
+        state_keep_prob=1.0,
+        seq_lens=None,
+        gru=False,
+        residual_connections=False):
+    if gru:
+        cell = tf.nn.rnn_cell.GRUCell
+    else:
+        cell = tf.contrib.rnn.LSTMCell
+
+    fw_cells = [
+        dropout_wrapper(
+            cell=cell(output_size),
+            is_training=is_training,
+            state_keep_prob=state_keep_prob,
+            output_keep_prob=output_keep_prob) for i in range(num_layers)]
+
+    bw_cells = [
+        dropout_wrapper(
+            cell=cell(output_size),
+            is_training=is_training,
+            state_keep_prob=state_keep_prob,
+            output_keep_prob=output_keep_prob) for i in range(num_layers)]
+    return sticker_graph.vendored.stack_bidirectional_dynamic_rnn(
+        fw_cells,
+        bw_cells,
+        inputs,
+        dtype=tf.float32,
+        sequence_length=seq_lens,
+        residual_connections=residual_connections)

--- a/sticker-graph/sticker_graph/rnn_model.py
+++ b/sticker-graph/sticker_graph/rnn_model.py
@@ -2,62 +2,7 @@ import tensorflow as tf
 from tensorflow.contrib.layers import batch_norm
 
 from sticker_graph.model import Model
-import sticker_graph.vendored
-
-def dropout_wrapper(
-        cell,
-        is_training,
-        output_keep_prob=1.0,
-        state_keep_prob=1.0):
-    output_keep_prob = tf.cond(
-        is_training,
-        lambda: tf.constant(output_keep_prob),
-        lambda: tf.constant(1.0))
-    state_keep_prob = tf.cond(
-        is_training,
-        lambda: tf.constant(state_keep_prob),
-        lambda: tf.constant(1.0))
-    return tf.contrib.rnn.DropoutWrapper(
-        cell,
-        output_keep_prob=output_keep_prob,
-        state_keep_prob=state_keep_prob)
-
-
-def bidi_rnn_layers(
-        is_training,
-        inputs,
-        num_layers=1,
-        output_size=50,
-        output_keep_prob=1.0,
-        state_keep_prob=1.0,
-        seq_lens=None,
-        gru=False,
-        residual_connections=False):
-    if gru:
-        cell = tf.nn.rnn_cell.GRUCell
-    else:
-        cell = tf.contrib.rnn.LSTMCell
-
-    fw_cells = [
-        dropout_wrapper(
-            cell=cell(output_size),
-            is_training=is_training,
-            state_keep_prob=state_keep_prob,
-            output_keep_prob=output_keep_prob) for i in range(num_layers)]
-
-    bw_cells = [
-        dropout_wrapper(
-            cell=cell(output_size),
-            is_training=is_training,
-            state_keep_prob=state_keep_prob,
-            output_keep_prob=output_keep_prob) for i in range(num_layers)]
-    return sticker_graph.vendored.stack_bidirectional_dynamic_rnn(
-        fw_cells,
-        bw_cells,
-        inputs,
-        dtype=tf.float32,
-        sequence_length=seq_lens,
-        residual_connections=residual_connections)
+from sticker_graph.rnn import bidi_rnn_layers
 
 
 class RNNModel(Model):
@@ -69,14 +14,9 @@ class RNNModel(Model):
 
         self.setup_placeholders()
 
-        inputs = tf.contrib.layers.dropout(
-            self.inputs,
-            keep_prob=args.keep_prob_input,
-            is_training=self.is_training)
-
         hidden_states, _, _ = bidi_rnn_layers(
             self.is_training,
-            inputs,
+            self.inputs,
             num_layers=args.rnn_layers,
             output_size=args.hidden_size,
             output_keep_prob=args.keep_prob,

--- a/sticker-graph/sticker_graph/transformer_model.py
+++ b/sticker-graph/sticker_graph/transformer_model.py
@@ -259,11 +259,7 @@ class TransformerModel(Model):
             raise NotImplementedError('Activation %s is not available.'
                                       % args.activation)
 
-        inputs = tf.contrib.layers.dropout(
-            self.inputs,
-            keep_prob=args.keep_prob_input,
-            is_training=self.is_training)
-
+        inputs = self.inputs
         if not args.pass_inputs:
             inputs = tf.layers.dense(inputs, args.outer_hsize, activation)
         else:

--- a/sticker-graph/sticker_graph/write_helper.py
+++ b/sticker-graph/sticker_graph/write_helper.py
@@ -75,9 +75,43 @@ def get_common_parser():
         type=str,
         help='output graph file')
     parser.add_argument(
+        "--byte_embed_size",
+        type=int,
+        help="size of character embeddings",
+        default=25)
+    parser.add_argument(
         "--crf",
         help="use CRF layer for classification",
         action="store_true")
+    parser.add_argument(
+        "--subword_gru",
+        help="use GRU RNN cells in the character RNN",
+        action="store_true")
+    parser.add_argument(
+        "--subword_hidden_size",
+        type=int,
+        help="character RNN hidden size per direction",
+        default=25)
+    parser.add_argument(
+        "--subword_keep_prob",
+        type=float,
+        help="character RNN dropout keep probability",
+        default=0.6)
+    parser.add_argument(
+        "--subword_layers",
+        type=int,
+        help="character RNN hidden layers",
+        default=1)
+    parser.add_argument(
+        "--subword_len",
+        type=int,
+        help="number of characters in character-based representations",
+        default=20)
+    parser.add_argument(
+        "--subword_residual",
+        action='store_true',
+        help="use character RNN residual skip connections"
+    )
     parser.add_argument(
         "--top_k",
         type=int,

--- a/sticker-graph/testdata/sticker.shapes
+++ b/sticker-graph/testdata/sticker.shapes
@@ -1,3 +1,4 @@
 n_labels = 13
+subwords = true
 token_embed_dims = 300
 tag_embed_dims = 50

--- a/sticker-utils/src/config.rs
+++ b/sticker-utils/src/config.rs
@@ -17,7 +17,7 @@ use crate::CborRead;
 #[serde(deny_unknown_fields)]
 pub struct Config {
     pub labeler: Labeler,
-    pub embeddings: Embeddings,
+    pub input: Input,
     pub model: ModelConfig,
 }
 
@@ -30,9 +30,9 @@ impl Config {
         let config_path = config_path.as_ref();
 
         self.labeler.labels = relativize_path(config_path, &self.labeler.labels)?;
-        self.embeddings.word.filename =
-            relativize_path(config_path, &self.embeddings.word.filename)?;
-        if let Some(ref mut embeddings) = self.embeddings.tag {
+        self.input.embeddings.word.filename =
+            relativize_path(config_path, &self.input.embeddings.word.filename)?;
+        if let Some(ref mut embeddings) = self.input.embeddings.tag {
             embeddings.filename = relativize_path(config_path, &embeddings.filename)?;
         }
         self.model.graph = relativize_path(config_path, &self.model.graph)?;
@@ -92,6 +92,14 @@ pub enum EmbeddingAlloc {
 pub enum EncoderType {
     RelativePosition,
     RelativePOS,
+}
+
+/// Input configuration
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Input {
+    pub embeddings: Embeddings,
+    pub subwords: bool,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use sticker::tensorflow::ModelConfig;
 use sticker::Layer;
 
-use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Labeler, LabelerType, TomlRead};
+use super::{Config, Embedding, EmbeddingAlloc, Embeddings, Input, Labeler, LabelerType, TomlRead};
 
 lazy_static! {
     static ref BASIC_LABELER_CHECK: Config = Config {
@@ -13,15 +13,18 @@ lazy_static! {
             labels: "sticker.labels".to_owned(),
             read_ahead: 10,
         },
-        embeddings: Embeddings {
-            word: Embedding {
-                filename: "word-vectors.bin".into(),
-                alloc: EmbeddingAlloc::Mmap,
+        input: Input {
+            embeddings: Embeddings {
+                word: Embedding {
+                    filename: "word-vectors.bin".into(),
+                    alloc: EmbeddingAlloc::Mmap,
+                },
+                tag: Some(Embedding {
+                    filename: "tag-vectors.bin".into(),
+                    alloc: EmbeddingAlloc::Read,
+                }),
             },
-            tag: Some(Embedding {
-                filename: "tag-vectors.bin".into(),
-                alloc: EmbeddingAlloc::Read,
-            }),
+            subwords: true,
         },
         model: ModelConfig {
             batch_size: 128,

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -3,7 +3,7 @@ pub use crate::app::sticker_app;
 
 mod config;
 pub use crate::config::{
-    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Labeler, LabelerType,
+    Config, Embedding, EmbeddingAlloc, Embeddings, EncoderType, Input, Labeler, LabelerType,
 };
 
 mod progress;

--- a/sticker-utils/src/tagger_wrapper.rs
+++ b/sticker-utils/src/tagger_wrapper.rs
@@ -45,10 +45,11 @@ impl TaggerWrapper {
     /// Create a tagger from the given configuration.
     pub fn new(config: &Config) -> Fallible<Self> {
         let embeddings = config
+            .input
             .embeddings
             .load_embeddings()
             .with_context(|e| format!("Cannot load embeddings: {}", e))?;
-        let vectorizer = SentVectorizer::new(embeddings);
+        let vectorizer = SentVectorizer::new(embeddings, config.input.subwords);
 
         let graph_reader = File::open(&config.model.graph).with_context(|e| {
             format!(

--- a/sticker-utils/testdata/sticker.conf
+++ b/sticker-utils/testdata/sticker.conf
@@ -3,11 +3,14 @@
   labels = "sticker.labels"
   read_ahead = 10
 
-[embeddings.word]
+[input]
+  subwords = true
+
+[input.embeddings.word]
   filename = "word-vectors.bin"
   alloc = "mmap"
 
-[embeddings.tag]
+[input.embeddings.tag]
   filename = "tag-vectors.bin"
   alloc = "read"
 

--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -4,7 +4,7 @@ pub use crate::collector::{Collector, NoopCollector};
 pub mod encoder;
 
 mod input;
-pub use crate::input::{Embeddings, LayerEmbeddings, SentVectorizer};
+pub use crate::input::{Embeddings, InputVector, LayerEmbeddings, SentVectorizer};
 
 mod numberer;
 pub use crate::numberer::Numberer;

--- a/sticker/src/tensorflow/dataset.rs
+++ b/sticker/src/tensorflow/dataset.rs
@@ -129,6 +129,7 @@ where
             batch_sentences.len(),
             max_seq_len,
             self.vectorizer.input_len(),
+            self.vectorizer.has_subwords(),
         );
 
         for sentence in batch_sentences {
@@ -144,7 +145,7 @@ where
                     .collect::<Vec<_>>(),
                 Err(err) => return Some(Err(err)),
             };
-            builder.add_with_labels(&inputs, &labels);
+            builder.add_with_labels(inputs, &labels);
         }
 
         Some(Ok(builder))


### PR DESCRIPTION
When subword representations are enabled, sticker builds a string
tensor containing each form in the input. The forms are converted to
(truncated) byte representations in the Tensorflow graph. Each byte is
then mapped to a byte embedding. Subword representations are then
formed by applying a bidirectional RNN to the sequence of byte
embeddings.

In order to support the configuration of subword embeddings, the
sticker configuration format has been adjusted. An `input` section has
been added, which holds the new `subwords` boolean option. The
`embeddings` section is now a subsection of `input`. The use of
subword representations is communicated to the graph writers through
the shapes file.

---

Sorry for the large changeset! Adding subword representations touches
many parts of sticker. This should be the last *large* change before
sticker 1.0 and also the last time an incompatible change is made to the
configuration file format before 1.0.