### PR TITLE
Fix byte encoding

### DIFF
--- a/sticker-graph/sticker_graph/write_helper.py
+++ b/sticker-graph/sticker_graph/write_helper.py
@@ -101,12 +101,12 @@ def get_common_parser():
         "--subword_layers",
         type=int,
         help="character RNN hidden layers",
-        default=1)
+        default=2)
     parser.add_argument(
         "--subword_len",
         type=int,
         help="number of characters in character-based representations",
-        default=20)
+        default=40)
     parser.add_argument(
         "--subword_residual",
         action='store_true',


### PR DESCRIPTION
tf.strings.unicode_decode decodes to unicode codepoints. So, any non-latin-1
character falls outside the range. This change introduces actual byte
encodings.

In some experiments, I found that with real byte representations, it helps
to have two layers in the byte RNN (presumably to combine characters with
multi-byte encodings), so this also changes the default hyperparameters.