### PR TITLE
Bump finalfusion dependency to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,11 +303,10 @@ dependencies = [
 
 [[package]]
 name = "finalfusion"
-version = "0.7.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -316,6 +315,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reductive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -958,6 +958,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "serde"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_cbor"
@@ -1007,7 +1010,7 @@ dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "conllx 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1036,7 +1039,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "conllx 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "finalfusion 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "finalfusion 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,7 +1281,7 @@ dependencies = [
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum filetime 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd7380b54ced79dda72ecc35cc4fbbd1da6bba54afaa37e96fd1c2a308cd469"
-"checksum finalfusion 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "040f6b1d829f76dd459bb5ebb91943a4de06954432eb8aced3b58604b48c3a05"
+"checksum finalfusion 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4928d7bc283231dd3df6c4aaabcf79f0fb7d943638f1995195b8a4025662e074"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "550934ad4808d5d39365e5d61727309bf18b3b02c6c56b729cb92e7dd84bc3d8"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/sticker-utils/Cargo.toml
+++ b/sticker-utils/Cargo.toml
@@ -15,7 +15,7 @@ license-file = "../LICENSE.md"
 clap = "2"
 conllx = "0.11"
 failure = "0.1"
-finalfusion = "0.7.1"
+finalfusion = "0.9"
 indicatif = "0.11"
 ordered-float = { version = "1", features = ["serde"] }
 serde = "1"

--- a/sticker/Cargo.toml
+++ b/sticker/Cargo.toml
@@ -14,7 +14,7 @@ license-file = "../LICENSE.md"
 [dependencies]
 conllx = "0.11"
 failure = "0.1"
-finalfusion = "0.7.1"
+finalfusion = "0.9"
 itertools = "0.8"
 ndarray = "0.12"
 ndarray-tensorflow = "0.2"

--- a/sticker/src/input.rs
+++ b/sticker/src/input.rs
@@ -1,10 +1,9 @@
 use conllx::graph::{Node, Sentence};
 use failure::{format_err, Error};
 use finalfusion::{
+    chunks::storage::{CowArray, CowArray1, StorageWrap},
+    chunks::vocab::VocabWrap,
     embeddings::Embeddings as FiFuEmbeddings,
-    storage::StorageWrap,
-    storage::{CowArray, CowArray1},
-    vocab::VocabWrap,
 };
 use ndarray::Array1;
 


### PR DESCRIPTION
This brings (among other things) support for memory-mapped quantized
embeddings.