### PR TITLE
Update sticker-tag and sticker-server to support pipelines

### DIFF
--- a/sticker-utils/src/app.rs
+++ b/sticker-utils/src/app.rs
@@ -1,6 +1,9 @@
 use clap::{App, AppSettings, Arg};
 
-static CONFIG: &str = "CONFIG";
+pub static BATCH_SIZE: &str = "BATCH_SIZE";
+pub static CONFIG: &str = "CONFIG";
+pub static CONFIGS: &str = "CONFIGS";
+pub static READ_AHEAD: &str = "READ_AHEAD";
 
 static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::DontCollapseArgsInUsage,
@@ -14,4 +17,27 @@ pub fn sticker_app<'a, 'b>(name: &str) -> App<'a, 'b> {
             .index(1)
             .required(true),
     )
+}
+
+pub fn sticker_pipeline_app<'a, 'b>(name: &str) -> App<'a, 'b> {
+    App::new(name)
+        .settings(DEFAULT_CLAP_SETTINGS)
+        .arg(
+            Arg::with_name(CONFIGS)
+                .help("Sticker configuration files")
+                .min_values(1)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name(BATCH_SIZE)
+                .help("Batch size")
+                .long("batchsize")
+                .default_value("256"),
+        )
+        .arg(
+            Arg::with_name(READ_AHEAD)
+                .help("Readahead (number of batches)")
+                .long("readahead")
+                .default_value("10"),
+        )
 }

--- a/sticker-utils/src/bin/sticker-prepare.rs
+++ b/sticker-utils/src/bin/sticker-prepare.rs
@@ -13,9 +13,8 @@ use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::{Collector, Embeddings, NoopCollector, Numberer, SentVectorizer};
-use sticker_utils::{sticker_app, CborWrite, Config, EncoderType, LabelerType, TomlRead};
+use sticker_utils::{app, CborWrite, Config, EncoderType, LabelerType, TomlRead};
 
-static CONFIG: &str = "CONFIG";
 static TRAIN_DATA: &str = "TRAIN_DATA";
 static SHAPES: &str = "SHAPES";
 
@@ -37,12 +36,12 @@ pub struct PrepareApp {
 
 impl PrepareApp {
     fn new() -> Self {
-        let matches = sticker_app("sticker-prepare")
+        let matches = app::sticker_app("sticker-prepare")
             .arg(Arg::with_name(TRAIN_DATA).help("Training data").index(2))
             .arg(Arg::with_name(SHAPES).help("Shape output file").index(3))
             .get_matches();
 
-        let config = matches.value_of(CONFIG).unwrap().into();
+        let config = matches.value_of(app::CONFIG).unwrap().into();
         let train_data = matches.value_of(TRAIN_DATA).map(ToOwned::to_owned);
         let shapes = matches.value_of(SHAPES).map(ToOwned::to_owned);
 

--- a/sticker-utils/src/bin/sticker-pretrain.rs
+++ b/sticker-utils/src/bin/sticker-pretrain.rs
@@ -14,11 +14,10 @@ use sticker::encoder::{CategoricalEncoder, SentenceEncoder};
 use sticker::tensorflow::{ConllxDataSet, DataSet, TaggerGraph, TaggerTrainer};
 use sticker::{Numberer, SentVectorizer};
 use sticker_utils::{
-    sticker_app, CborRead, CompletedUnit, Config, EncoderType, LabelerType, ReadProgress,
-    SaveSchedule, SaveScheduler, TomlRead,
+    app, CborRead, CompletedUnit, Config, EncoderType, LabelerType, ReadProgress, SaveSchedule,
+    SaveScheduler, TomlRead,
 };
 
-static CONFIG: &str = "CONFIG";
 static EPOCHS: &str = "EPOCHS";
 static INITIAL_LR: &str = "INITIAL_LR";
 static MAX_LEN: &str = "MAX_LEN";
@@ -42,7 +41,7 @@ pub struct PretrainApp {
 
 impl PretrainApp {
     fn new() -> Self {
-        let matches = sticker_app("sticker-pretrain")
+        let matches = app::sticker_app("sticker-pretrain")
             .arg(
                 Arg::with_name(CONTINUE)
                     .long("continue")
@@ -98,7 +97,7 @@ impl PretrainApp {
             )
             .get_matches();
 
-        let config = matches.value_of(CONFIG).unwrap().into();
+        let config = matches.value_of(app::CONFIG).unwrap().into();
         let epochs = matches
             .value_of(EPOCHS)
             .unwrap()

--- a/sticker-utils/src/bin/sticker-tag.rs
+++ b/sticker-utils/src/bin/sticker-tag.rs
@@ -1,37 +1,64 @@
-use std::fs::File;
 use std::io::BufWriter;
 
 use clap::Arg;
 use conllx::io::{ReadSentence, Reader, WriteSentence, Writer};
 use stdinout::{Input, OrExit, Output};
 
-use sticker_utils::{sticker_app, Config, SentProcessor, TaggerSpeed, TaggerWrapper, TomlRead};
+use sticker_utils::app;
+use sticker_utils::{Pipeline, SentProcessor, TaggerSpeed};
 
-static CONFIG: &str = "CONFIG";
 static INPUT: &str = "INPUT";
 static OUTPUT: &str = "OUTPUT";
 
 pub struct TagApp {
-    config: String,
+    batch_size: usize,
+    configs: Vec<String>,
     input: Option<String>,
     output: Option<String>,
+    read_ahead: usize,
 }
 
 impl TagApp {
     fn new() -> Self {
-        let matches = sticker_app("sticker-tag")
-            .arg(Arg::with_name(INPUT).help("Input data").index(2))
-            .arg(Arg::with_name(OUTPUT).help("Output data").index(3))
+        let matches = app::sticker_pipeline_app("sticker-tag")
+            .arg(
+                Arg::with_name(INPUT)
+                    .help("Input data")
+                    .long("input")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name(OUTPUT)
+                    .help("Output data")
+                    .long("output")
+                    .takes_value(true),
+            )
             .get_matches();
 
-        let config = matches.value_of(CONFIG).unwrap().into();
+        let batch_size = matches
+            .value_of(app::BATCH_SIZE)
+            .unwrap()
+            .parse()
+            .or_exit("Cannot parse batch size", 1);
+        let configs = matches
+            .values_of(app::CONFIGS)
+            .unwrap()
+            .map(ToOwned::to_owned)
+            .collect();
         let input = matches.value_of(INPUT).map(ToOwned::to_owned);
         let output = matches.value_of(OUTPUT).map(ToOwned::to_owned);
+        let read_ahead = matches
+            .value_of(app::READ_AHEAD)
+            .unwrap()
+            .parse()
+            .or_exit("Cannot parse number of batches to read ahead", 1);
 
         TagApp {
-            config,
+            batch_size,
+            configs,
             input,
             output,
+            read_ahead,
         }
     }
 }
@@ -45,41 +72,28 @@ impl Default for TagApp {
 fn main() {
     let app = TagApp::new();
 
-    let config_file = File::open(&app.config).or_exit(
-        format!("Cannot open configuration file '{}'", app.config),
-        1,
-    );
-    let mut config = Config::from_toml_read(config_file).or_exit("Cannot parse configuration", 1);
-    config
-        .relativize_paths(app.config)
-        .or_exit("Cannot relativize paths in configuration", 1);
+    let pipeline = Pipeline::new_from_config_filenames(&app.configs)
+        .or_exit("Cannot construct tagging pipeline", 1);
 
-    let input = Input::from(app.input);
+    let input = Input::from(app.input.clone());
     let reader = Reader::new(input.buf_read().or_exit("Cannot open input for reading", 1));
 
-    let output = Output::from(app.output);
+    let output = Output::from(app.output.clone());
     let writer = Writer::new(BufWriter::new(
         output.write().or_exit("Cannot open output for writing", 1),
     ));
 
-    let tagger = TaggerWrapper::new(&config).or_exit("Cannot construct tagger", 1);
-
-    process(&config, tagger, reader, writer);
+    process(&app, pipeline, reader, writer);
 }
 
-fn process<R, W>(config: &Config, tagger: TaggerWrapper, read: R, write: W)
+fn process<R, W>(app: &TagApp, pipeline: Pipeline, read: R, write: W)
 where
     R: ReadSentence,
     W: WriteSentence,
 {
     let mut speed = TaggerSpeed::new();
 
-    let mut sent_proc = SentProcessor::new(
-        &tagger,
-        write,
-        config.model.batch_size,
-        config.labeler.read_ahead,
-    );
+    let mut sent_proc = SentProcessor::new(&pipeline, write, app.batch_size, app.read_ahead);
 
     for sentence in read.sentences() {
         let sentence = sentence.or_exit("Cannot parse sentence", 1);

--- a/sticker-utils/src/bin/sticker-train.rs
+++ b/sticker-utils/src/bin/sticker-train.rs
@@ -16,11 +16,10 @@ use sticker::tensorflow::{
 };
 use sticker::{Numberer, SentVectorizer};
 use sticker_utils::{
-    sticker_app, CborRead, CompletedUnit, Config, EncoderType, LabelerType, ReadProgress,
-    SaveSchedule, SaveScheduler, TomlRead,
+    app, CborRead, CompletedUnit, Config, EncoderType, LabelerType, ReadProgress, SaveSchedule,
+    SaveScheduler, TomlRead,
 };
 
-static CONFIG: &str = "CONFIG";
 static INITIAL_LR: &str = "INITIAL_LR";
 static LR_SCALE: &str = "LR_SCALE";
 static LR_PATIENCE: &str = "LR_PATIENCE";
@@ -61,7 +60,7 @@ impl TrainApp {
 
 impl TrainApp {
     fn new() -> Self {
-        let matches = sticker_app("sticker-train")
+        let matches = app::sticker_app("sticker-train")
             .arg(
                 Arg::with_name(CONTINUE)
                     .long("continue")
@@ -124,7 +123,7 @@ impl TrainApp {
             )
             .get_matches();
 
-        let config = matches.value_of(CONFIG).unwrap().into();
+        let config = matches.value_of(app::CONFIG).unwrap().into();
         let initial_lr = matches
             .value_of(INITIAL_LR)
             .unwrap()

--- a/sticker-utils/src/config.rs
+++ b/sticker-utils/src/config.rs
@@ -106,7 +106,11 @@ pub struct Input {
 #[serde(deny_unknown_fields)]
 pub struct Labeler {
     pub labels: String,
-    pub read_ahead: usize,
+
+    // Not used anymore, changed from usize to Option<usize> in order
+    // to read older configuration files.
+    pub read_ahead: Option<usize>,
+
     pub labeler_type: LabelerType,
 }
 

--- a/sticker-utils/src/config_tests.rs
+++ b/sticker-utils/src/config_tests.rs
@@ -11,7 +11,7 @@ lazy_static! {
         labeler: Labeler {
             labeler_type: LabelerType::Sequence(Layer::Feature("tf".to_string())),
             labels: "sticker.labels".to_owned(),
-            read_ahead: 10,
+            read_ahead: Some(10),
         },
         input: Input {
             embeddings: Embeddings {

--- a/sticker-utils/src/lib.rs
+++ b/sticker-utils/src/lib.rs
@@ -1,5 +1,4 @@
-mod app;
-pub use crate::app::sticker_app;
+pub mod app;
 
 mod config;
 pub use crate::config::{

--- a/sticker-utils/src/sent_proc.rs
+++ b/sticker-utils/src/sent_proc.rs
@@ -2,7 +2,7 @@ use conllx::graph::Sentence;
 use conllx::io::WriteSentence;
 use failure::Error;
 
-use crate::TaggerWrapper;
+use crate::Pipeline;
 
 // Wrap the sentence processing in a data type. This has the benefit that
 // we can use a destructor to write the last (possibly incomplete) batch.
@@ -10,7 +10,7 @@ pub struct SentProcessor<'a, W>
 where
     W: WriteSentence,
 {
-    tagger: &'a TaggerWrapper,
+    pipeline: &'a Pipeline,
     writer: W,
     batch_size: usize,
     read_ahead: usize,
@@ -21,12 +21,12 @@ impl<'a, W> SentProcessor<'a, W>
 where
     W: WriteSentence,
 {
-    pub fn new(tagger: &'a TaggerWrapper, writer: W, batch_size: usize, read_ahead: usize) -> Self {
+    pub fn new(pipeline: &'a Pipeline, writer: W, batch_size: usize, read_ahead: usize) -> Self {
         assert!(batch_size > 0, "Batch size should at least be 1.");
         assert!(read_ahead > 0, "Read ahead should at least be 1.");
 
         SentProcessor {
-            tagger,
+            pipeline,
             writer,
             batch_size,
             read_ahead,
@@ -51,7 +51,7 @@ where
 
         // Split in batches, tag, and merge results.
         for batch in sent_refs.chunks_mut(self.batch_size) {
-            self.tagger.tag_sentences(batch)?;
+            self.pipeline.tag_sentences(batch)?;
         }
 
         // Write out sentences.

--- a/sticker-utils/src/serialization.rs
+++ b/sticker-utils/src/serialization.rs
@@ -23,6 +23,11 @@ impl TomlRead for Config {
         let mut data = String::new();
         read.read_to_string(&mut data)?;
         let config: Config = toml::from_str(&data)?;
+
+        if config.labeler.read_ahead.is_some() {
+            eprintln!("The labeler.read_ahead option is deprecated and not used anymore");
+        }
+
         Ok(config)
     }
 }


### PR DESCRIPTION
With this change, both programs accept multiple configuration files as
arguments. The models from the configuration files will be loaded and
used as a pipeline.

For `sticker-tag` this change means that the optional input/output
filename arguments have been replaced by the `--input` and `--output` options.