### PR TITLE
Add support for obtaining the top-k labels with their probabilities

### DIFF
--- a/sticker/src/lib.rs
+++ b/sticker/src/lib.rs
@@ -10,6 +10,6 @@ mod numberer;
 pub use crate::numberer::Numberer;
 
 mod tag;
-pub use crate::tag::{Layer, LayerValue, ModelPerformance, Tag};
+pub use crate::tag::{Layer, LayerValue, ModelPerformance, Tag, TopK, TopKLabels};
 
 pub mod tensorflow;

--- a/sticker/src/tag.rs
+++ b/sticker/src/tag.rs
@@ -1,9 +1,11 @@
-use std::borrow::BorrowMut;
+use std::borrow::{Borrow, BorrowMut};
 
 use conllx::graph::Sentence;
 use conllx::token::{Features, Token};
 use failure::Fallible;
 use serde_derive::{Deserialize, Serialize};
+
+use crate::encoder::{EncodingProb, SentenceDecoder};
 
 /// Tagging layer.
 #[serde(rename_all = "lowercase")]
@@ -61,7 +63,24 @@ impl LayerValue for Token {
 
 /// Trait for sequence taggers.
 pub trait Tag {
+    /// Tag sentences.
     fn tag_sentences(&self, sentences: &mut [impl BorrowMut<Sentence>]) -> Fallible<()>;
+}
+
+pub type TopKLabels<'a, L> = Vec<Vec<Vec<L>>>;
+
+/// Trait for predicting the top-k labels for tokens.
+pub trait TopK<D>
+where
+    D: SentenceDecoder,
+{
+    /// Get the top-k labels for all tokens.
+    ///
+    /// *k* is fixed in the model graph.
+    fn top_k(
+        &self,
+        sentences: &[impl Borrow<Sentence>],
+    ) -> Fallible<TopKLabels<EncodingProb<D::Encoding>>>;
 }
 
 /// Results of validation.


### PR DESCRIPTION
- Adds a `TopK` trait and implements this for the Tensorflow `Tagger`.
- Factor out a `Tagger` method to get the top-k numerical labels,
  which is then both used for the `TopK` implementation and the `Tag`
  implementation.
- `CategorialEncoder::decode_without_inner` was added to just get the
  non-numerical labels. `CategoricalEncoder::decode` calls the inner
  encoder, which will update the sentence.
- Update `TaggerWrapper` to add a `top_k` method. Here, the labels are
  converted to strings. The goal of `TaggerWrapper` is to be devoid
  of types. Unfortunately, we do not have a trait for encodings
  (since they can be anything), so returning the individual labels
  as a `Box<Encoding>` is not possible. So, we return strings as
  an approximation.

---

I am not sure who the best reviewer for this code is. One of the reasons to add this is so that @DiveFish can inspect the top-k labels for interesting constructions. But @twuebi and @sebpuetz are more familiar with the code.