### PR TITLE
Sentence iterator adapter.

### DIFF
--- a/sticker/src/tensorflow/dataset.rs
+++ b/sticker/src/tensorflow/dataset.rs
@@ -2,8 +2,9 @@ use std::hash::Hash;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::usize;
 
-use conllx::io::{ReadSentence, Reader, Sentences};
-use failure::Fallible;
+use conllx::graph::Sentence;
+use conllx::io::{ReadSentence, Reader};
+use failure::{Error, Fallible};
 
 use super::tensor::{LabelTensor, TensorBuilder};
 use crate::encoder::{CategoricalEncoder, SentenceEncoder};
@@ -45,6 +46,27 @@ impl<R> ConllxDataSet<R> {
     pub fn new(read: R) -> Self {
         ConllxDataSet(read)
     }
+
+    /// Returns an `Iterator` over `Result<Sentence, Error>`.
+    ///
+    /// Depending on the parameters the returned iterator filters
+    /// sentences by their lengths or returns the sentences in
+    /// sequence without filtering them.
+    ///
+    /// If `max_len` == `usize::MAX`, no filtering is performed.
+    fn get_sentence_iter<'a>(
+        reader: R,
+        max_len: usize,
+    ) -> Box<dyn Iterator<Item = Result<Sentence, Error>> + 'a>
+    where
+        R: ReadSentence + 'a,
+    {
+        if max_len < usize::MAX {
+            Box::new(reader.sentences().filter_by_len(max_len))
+        } else {
+            Box::new(reader.sentences())
+        }
+    }
 }
 
 impl<'a, 'ds, E, R> DataSet<'a, E> for &'ds mut ConllxDataSet<R>
@@ -53,7 +75,7 @@ where
     E::Encoding: 'a + Clone + Eq + Hash,
     R: Read + Seek,
 {
-    type Iter = ConllxIter<'a, E, Reader<BufReader<&'ds mut R>>>;
+    type Iter = ConllxIter<'a, E, Box<dyn Iterator<Item = Result<Sentence, Error>> + 'ds>>;
 
     fn batches(
         self,
@@ -70,31 +92,29 @@ where
         Ok(ConllxIter {
             batch_size,
             encoder,
-            max_len,
-            sentences: reader.sentences(),
+            sentences: ConllxDataSet::get_sentence_iter(reader, max_len),
             vectorizer,
         })
     }
 }
 
-pub struct ConllxIter<'a, E, R>
+pub struct ConllxIter<'a, E, I>
 where
     E: SentenceEncoder,
     E::Encoding: Clone + Eq + Hash,
-    R: ReadSentence,
+    I: Iterator<Item = Result<Sentence, Error>>,
 {
     batch_size: usize,
-    max_len: usize,
     encoder: &'a mut CategoricalEncoder<E, E::Encoding>,
     vectorizer: &'a SentVectorizer,
-    sentences: Sentences<R>,
+    sentences: I,
 }
 
-impl<'a, E, R> Iterator for ConllxIter<'a, E, R>
+impl<'a, E, I> Iterator for ConllxIter<'a, E, I>
 where
     E: SentenceEncoder,
     E::Encoding: Clone + Eq + Hash,
-    R: ReadSentence,
+    I: Iterator<Item = Result<Sentence, Error>>,
 {
     type Item = Fallible<TensorBuilder<LabelTensor>>;
 
@@ -105,11 +125,7 @@ where
                 Ok(sentence) => sentence,
                 Err(err) => return Some(Err(err)),
             };
-
-            if sentence.len() <= self.max_len {
-                batch_sentences.push(sentence);
-            }
-
+            batch_sentences.push(sentence);
             if batch_sentences.len() == self.batch_size {
                 break;
             }
@@ -149,5 +165,48 @@ where
         }
 
         Some(Ok(builder))
+    }
+}
+
+/// Trait providing adapters for `conllx::io::Sentences`.
+pub trait SentenceIter: Sized {
+    fn filter_by_len(self, max_len: usize) -> LengthFilter<Self>;
+}
+
+impl<I> SentenceIter for I
+where
+    I: Iterator<Item = Result<Sentence, Error>>,
+{
+    fn filter_by_len(self, max_len: usize) -> LengthFilter<Self> {
+        LengthFilter {
+            inner: self,
+            max_len,
+        }
+    }
+}
+
+/// An Iterator adapter filtering sentences by maximum length.
+pub struct LengthFilter<I> {
+    inner: I,
+    max_len: usize,
+}
+
+impl<I> Iterator for LengthFilter<I>
+where
+    I: Iterator<Item = Result<Sentence, Error>>,
+{
+    type Item = Result<Sentence, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while let Some(sent) = self.inner.next() {
+            // Treat Err as length 0 to keep our type as Result<Sentence, Error>. The iterator
+            // will properly return the Error at a later point.
+            let len = sent.as_ref().map(|s| s.len()).unwrap_or(0);
+            if len > self.max_len {
+                continue;
+            }
+            return Some(sent);
+        }
+        None
     }
 }


### PR DESCRIPTION
This PR introduces a trait `SentenceIter` that provides adapters for `conllx::io::Sentences`. 

This trait makes it easier to introduce other operations such as shuffling via a buffer or local sorting.

***

In initial experiments buffered shuffling gave better results while converging faster than linear sampling.

***

The design is modelled after https://github.com/finalfusion/finalfrontier/blob/master/src/deps.rs