### PR TITLE
Also add the --batchsize option to training apps

### DIFF
--- a/sticker-utils/src/traits.rs
+++ b/sticker-utils/src/traits.rs
@@ -44,6 +44,7 @@ pub trait StickerPipelineApp: StickerApp {
 }
 
 pub trait StickerTrainApp: StickerApp {
+    const BATCH_SIZE: &'static str = "BATCH_SIZE";
     const CONFIG: &'static str = "CONFIG";
 
     fn train_app<'a, 'b>(name: &str) -> App<'a, 'b> {
@@ -55,6 +56,12 @@ pub trait StickerTrainApp: StickerApp {
                     .help("Sticker configuration")
                     .index(1)
                     .required(true),
+            )
+            .arg(
+                Arg::with_name(Self::BATCH_SIZE)
+                    .help("Batch size")
+                    .long("batchsize")
+                    .default_value("256"),
             )
     }
 }

--- a/sticker/src/tensorflow/tagger.rs
+++ b/sticker/src/tensorflow/tagger.rs
@@ -23,9 +23,8 @@ use crate::{SentVectorizer, Tag, TopK, TopKLabels};
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ModelConfig {
-    /// Model batch size, should be kept constant between training and
-    /// prediction.
-    pub batch_size: usize,
+    /// Model batch size (unused).
+    pub batch_size: Option<usize>,
 
     /// Only allocate as much GPU memory as needed.
     #[serde(default)]
@@ -59,7 +58,7 @@ impl ModelConfig {
 impl Default for ModelConfig {
     fn default() -> Self {
         ModelConfig {
-            batch_size: 128,
+            batch_size: None,
             gpu_allow_growth: true,
             graph: String::new(),
             inter_op_parallelism_threads: 1,

--- a/sticker/src/wrapper/config.rs
+++ b/sticker/src/wrapper/config.rs
@@ -57,6 +57,10 @@ impl TomlRead for Config {
         read.read_to_string(&mut data)?;
         let config: Config = toml::from_str(&data)?;
 
+        if config.model.batch_size.is_some() {
+            eprintln!("The model.batch_size option is deprecated and not used anymore");
+        }
+
         if config.labeler.read_ahead.is_some() {
             eprintln!("The labeler.read_ahead option is deprecated and not used anymore");
         }
@@ -226,7 +230,7 @@ mod tests {
                 subwords: true,
             },
             model: ModelConfig {
-                batch_size: 128,
+                batch_size: Some(128),
                 gpu_allow_growth: true,
                 graph: "sticker.graph".to_owned(),
                 parameters: "sticker.model".to_owned(),


### PR DESCRIPTION
- The pipeline apps were already using the --batchsize option in place
  of the sticker configuration file. Make things consistent again by
  doing the same in the train apps.
- Add a warning that the 'model.batch_size' option is not used anymore
  if it is present in the configuration.

Fixes #151.