### PR TITLE
Make `max_len` an Option.

### DIFF
--- a/sticker-utils/src/subcommands/pretrain.rs
+++ b/sticker-utils/src/subcommands/pretrain.rs
@@ -63,7 +63,7 @@ pub struct PretrainApp {
     epochs: usize,
     initial_lr: NotNan<f32>,
     warmup_steps: usize,
-    max_len: usize,
+    max_len: Option<usize>,
     parameters: Option<String>,
     saver: PretrainSaver,
     train_data: String,
@@ -311,6 +311,7 @@ impl StickerApp for PretrainApp {
                 Arg::with_name(MAX_LEN)
                     .long("maxlen")
                     .value_name("N")
+                    .takes_value(true)
                     .help("Ignore sentences longer than N tokens"),
             )
             .arg(
@@ -366,8 +367,7 @@ impl StickerApp for PretrainApp {
 
         let max_len = matches
             .value_of(MAX_LEN)
-            .map(|v| v.parse().or_exit("Cannot parse maximum sentence length", 1))
-            .unwrap_or(usize::MAX);
+            .map(|v| v.parse().or_exit("Cannot parse maximum sentence length", 1));
         let parameters = matches.value_of(CONTINUE).map(ToOwned::to_owned);
         let saver = matches
             .value_of(SAVE_BATCH)

--- a/sticker-utils/src/subcommands/train.rs
+++ b/sticker-utils/src/subcommands/train.rs
@@ -44,7 +44,7 @@ pub struct TrainApp {
     batch_size: usize,
     config: String,
     lr_schedule: LrSchedule,
-    max_len: usize,
+    max_len: Option<usize>,
     parameters: Option<String>,
     patience: usize,
     saver: BestEpochSaver<f32>,
@@ -289,6 +289,7 @@ impl StickerApp for TrainApp {
                 Arg::with_name(MAX_LEN)
                     .long("maxlen")
                     .value_name("N")
+                    .takes_value(true)
                     .help("Ignore sentences longer than N tokens"),
             )
             .arg(
@@ -343,8 +344,7 @@ impl StickerApp for TrainApp {
             .or_exit("Cannot parse learning rate scale", 1);
         let max_len = matches
             .value_of(MAX_LEN)
-            .map(|v| v.parse().or_exit("Cannot parse maximum sentence length", 1))
-            .unwrap_or(usize::MAX);
+            .map(|v| v.parse().or_exit("Cannot parse maximum sentence length", 1));
         let parameters = matches.value_of(CONTINUE).map(ToOwned::to_owned);
         let patience = matches
             .value_of(PATIENCE)

--- a/sticker/src/tensorflow/dataset.rs
+++ b/sticker/src/tensorflow/dataset.rs
@@ -34,7 +34,7 @@ where
         encoder: &'a mut CategoricalEncoder<E, E::Encoding>,
         vectorizer: &'a SentVectorizer,
         batch_size: usize,
-        max_len: usize,
+        max_len: Option<usize>,
     ) -> Fallible<Self::Iter>;
 }
 
@@ -56,15 +56,14 @@ impl<R> ConllxDataSet<R> {
     /// If `max_len` == `usize::MAX`, no filtering is performed.
     fn get_sentence_iter<'a>(
         reader: R,
-        max_len: usize,
+        max_len: Option<usize>,
     ) -> Box<dyn Iterator<Item = Result<Sentence, Error>> + 'a>
     where
         R: ReadSentence + 'a,
     {
-        if max_len < usize::MAX {
-            Box::new(reader.sentences().filter_by_len(max_len))
-        } else {
-            Box::new(reader.sentences())
+        match max_len {
+            Some(max_len) => Box::new(reader.sentences().filter_by_len(max_len)),
+            None => Box::new(reader.sentences()),
         }
     }
 }
@@ -82,7 +81,7 @@ where
         encoder: &'a mut CategoricalEncoder<E, E::Encoding>,
         vectorizer: &'a SentVectorizer,
         batch_size: usize,
-        max_len: usize,
+        max_len: Option<usize>,
     ) -> Fallible<Self::Iter> {
         // Rewind to the beginning of the data (if necessary).
         self.0.seek(SeekFrom::Start(0))?;


### PR DESCRIPTION
https://github.com/stickeritis/sticker/pull/142#discussion_r339971594

Before, setting `max_len` to `usize::max` disabled length filtering. Now `max_len` is optional, where `None` means no filtering.