### PR TITLE
Rewrite pretrain loop to support validation every N steps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfusion 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/sticker-utils/Cargo.toml
+++ b/sticker-utils/Cargo.toml
@@ -21,6 +21,7 @@ conllx = "0.12.1"
 failure = "0.1"
 finalfusion = "0.10"
 indicatif = "0.11"
+itertools = "0.8"
 ordered-float = { version = "1", features = ["serde"] }
 serde = "1"
 serde_cbor = "0.10"

--- a/sticker-utils/src/main.rs
+++ b/sticker-utils/src/main.rs
@@ -13,6 +13,8 @@ pub mod save;
 pub mod traits;
 use traits::StickerApp;
 
+pub mod util;
+
 static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
     AppSettings::DontCollapseArgsInUsage,
     AppSettings::UnifiedHelpMessage,

--- a/sticker-utils/src/progress.rs
+++ b/sticker-utils/src/progress.rs
@@ -20,6 +20,7 @@ where
 {
     pub fn new(mut read: R) -> io::Result<Self> {
         let len = read.seek(SeekFrom::End(0))? + 1;
+        read.seek(SeekFrom::Start(0))?;
         let progress_bar = ProgressBar::new(len);
         progress_bar
             .set_style(ProgressStyle::default_bar().template("{bar} {bytes}/{total_bytes}"));

--- a/sticker-utils/src/subcommands/pretrain.rs
+++ b/sticker-utils/src/subcommands/pretrain.rs
@@ -1,11 +1,12 @@
 use std::fs::File;
 use std::hash::Hash;
-use std::io::{BufReader, Seek, SeekFrom};
+use std::io::{BufReader, Read, Seek};
 use std::usize;
 
 use clap::{App, Arg, ArgMatches};
-use failure::{Error, Fallible};
-use indicatif::ProgressStyle;
+use failure::{Error, Fallible, ResultExt};
+use indicatif::{ProgressBar, ProgressStyle};
+use itertools::Itertools;
 use ordered_float::NotNan;
 use stdinout::OrExit;
 use sticker::encoder::categorical::ImmutableCategoricalEncoder;
@@ -13,13 +14,15 @@ use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::serialization::CborRead;
-use sticker::tensorflow::{ConllxDataSet, DataSet, TaggerGraph, TaggerTrainer};
+use sticker::tensorflow::{
+    ConllxDataSet, DataSet, LabelTensor, TaggerGraph, TaggerTrainer, TensorBuilder,
+};
 use sticker::wrapper::{Config, EncoderType, LabelerType, TomlRead};
 use sticker::{Numberer, SentVectorizer};
 
 use crate::progress::ReadProgress;
-use crate::save::{CompletedUnit, EpochAndBatchesSaver, EpochSaver, Save};
 use crate::traits::{StickerApp, StickerTrainApp};
+use crate::util::count_conllx_sentences;
 
 static EPOCHS: &str = "EPOCHS";
 static INITIAL_LR: &str = "INITIAL_LR";
@@ -27,49 +30,24 @@ static WARMUP: &str = "WARMUP";
 static MAX_LEN: &str = "MAX_LEN";
 static SHUFFLE: &str = "SHUFFLE";
 static CONTINUE: &str = "CONTINUE";
-static SAVE_BATCH: &str = "SAVE_BATCH";
+static EVAL_STEPS: &str = "EVAL_STEPS";
+static STEPS: &str = "N_STEPS";
 static TRAIN_DATA: &str = "TRAIN_DATA";
 static VALIDATION_DATA: &str = "VALIDATION_DATA";
 static LOGDIR: &str = "LOGDIR";
 
 #[derive(Clone)]
-pub enum PretrainSaver {
-    Epoch(EpochSaver<f32>),
-    EpochAndBatches(EpochAndBatchesSaver<f32>),
-}
-
-impl From<EpochSaver<f32>> for PretrainSaver {
-    fn from(saver: EpochSaver<f32>) -> Self {
-        PretrainSaver::Epoch(saver)
-    }
-}
-
-impl From<EpochAndBatchesSaver<f32>> for PretrainSaver {
-    fn from(saver: EpochAndBatchesSaver<f32>) -> Self {
-        PretrainSaver::EpochAndBatches(saver)
-    }
-}
-
-impl Save<f32> for PretrainSaver {
-    fn save(&mut self, trainer: &TaggerTrainer, completed: CompletedUnit<f32>) -> Fallible<()> {
-        match self {
-            PretrainSaver::Epoch(saver) => saver.save(trainer, completed),
-            PretrainSaver::EpochAndBatches(saver) => saver.save(trainer, completed),
-        }
-    }
-}
-
 pub struct PretrainApp {
     batch_size: usize,
     config: String,
-    epochs: usize,
+    eval_steps: usize,
     initial_lr: NotNan<f32>,
     warmup_steps: usize,
     max_len: Option<usize>,
     shuffle_buffer_size: Option<usize>,
     parameters: Option<String>,
-    saver: PretrainSaver,
     train_data: String,
+    train_duration: TrainDuration,
     validation_data: String,
     logdir: Option<String>,
 }
@@ -92,13 +70,33 @@ impl PretrainApp {
         Ok(trainer)
     }
 
+    fn open_dataset(file: &File) -> Fallible<ConllxDataSet<impl Read + Seek>> {
+        let read = BufReader::new(file.try_clone()?);
+        Ok(ConllxDataSet::new(read))
+    }
+
+    fn open_dataset_with_progress(
+        file: &File,
+        phase: &str,
+    ) -> Fallible<(ConllxDataSet<impl Read + Seek>, ProgressBar)> {
+        let read_progress =
+            ReadProgress::new(file.try_clone()?).or_exit("Cannot open file for reading", 1);
+        let progress_bar = read_progress.progress_bar().clone();
+        progress_bar.set_style(ProgressStyle::default_bar().template(&format!(
+            "[Time: {{elapsed_precise}}, ETA: {{eta_precise}}] {{bar}} {{percent}}% {} {{msg}}",
+            phase
+        )));
+
+        Ok((ConllxDataSet::new(read_progress), progress_bar))
+    }
+
     fn train_model_with_encoder<E>(
         &self,
         config: &Config,
         trainer: TaggerTrainer,
         encoder: E,
-        mut train_file: File,
-        mut validation_file: File,
+        train_file: File,
+        validation_file: File,
     ) -> Result<(), Error>
     where
         E: SentenceEncoder,
@@ -122,161 +120,180 @@ impl PretrainApp {
             .or_exit("Cannot load embeddings", 1);
         let vectorizer = SentVectorizer::new(embeddings, config.input.subwords);
 
-        let mut best_epoch = 0;
+        let mut best_step = 0;
         let mut best_acc = 0.0;
 
-        let train_size = train_file.metadata()?.len() as usize;
-
-        let mut saver = self.saver.clone();
         let mut global_step = 0;
+        let n_steps = self.train_duration.to_steps(&train_file, self.batch_size)?;
 
-        for epoch in 0..self.epochs {
-            let (loss, acc, global_step_after_epoch) = self.run_epoch(
-                &mut saver,
+        let train_progress = ProgressBar::new(n_steps as u64);
+        train_progress.set_style(ProgressStyle::default_bar().template(
+            "[Time: {elapsed_precise}, ETA: {eta_precise}] {bar} {percent}% train {msg}",
+        ));
+
+        // Continue performing steps until we are done.
+        while global_step < n_steps - 1 {
+            let mut train_dataset = Self::open_dataset(&train_file)?;
+            let train_batches = train_dataset.batches(
                 &categorical_encoder,
                 &vectorizer,
-                &trainer,
-                &mut train_file,
-                true,
-                train_size,
-                global_step,
-                epoch,
-            )?;
-            global_step = global_step_after_epoch;
-            eprintln!("Epoch {} (train, loss: {:.4}, acc: {:.4}", epoch, loss, acc);
-
-            let (loss, acc, _) = self.run_epoch(
-                &mut saver,
-                &categorical_encoder,
-                &vectorizer,
-                &trainer,
-                &mut validation_file,
-                false,
-                train_size,
-                global_step,
-                epoch,
+                self.batch_size,
+                self.max_len,
+                self.shuffle_buffer_size,
             )?;
 
-            saver
-                .save(&trainer, CompletedUnit::Epoch(acc))
-                .or_exit("Error saving model", 1);
+            for steps in &train_batches.chunks(self.eval_steps) {
+                let (_, _, global_step_after_steps) =
+                    self.train_steps(&train_progress, &trainer, steps, global_step, n_steps)?;
+                global_step = global_step_after_steps;
 
-            if acc > best_acc {
-                best_epoch = epoch;
-                best_acc = acc;
+                let (loss, acc) = self.validation_epoch(
+                    &trainer,
+                    &validation_file,
+                    &categorical_encoder,
+                    &vectorizer,
+                    global_step,
+                )?;
+
+                if acc > best_acc {
+                    best_step = global_step;
+                    best_acc = acc;
+
+                    trainer
+                        .save(format!("{}step-{}", "pretrain-", global_step))
+                        .context(format!("Cannot save model for step {}", global_step))?;
+                }
+
+                let step_status = if best_step == global_step { "🎉" } else { "" };
+
+                eprintln!("Step {} (validation): loss: {:.4}, acc: {:.4}, best step: {}, best acc: {:.4} {}\n",
+			  global_step, loss, acc, best_step, best_acc, step_status);
+
+                if global_step >= n_steps - 1 {
+                    break;
+                }
             }
-
-            let epoch_status = if best_epoch == epoch { "🎉" } else { "" };
-
-            eprintln!(
-            "Epoch {} (validation): loss: {:.4}, acc: {:.4}, best epoch: {}, best acc: {:.4} {}",
-            epoch, loss, acc, best_epoch, best_acc, epoch_status
-        );
         }
 
         Ok(())
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn run_epoch<E>(
+    fn train_steps(
         &self,
-        saver: &mut PretrainSaver,
-        encoder: &ImmutableCategoricalEncoder<E, E::Encoding>,
-        vectorizer: &SentVectorizer,
+        progress: &ProgressBar,
         trainer: &TaggerTrainer,
-        file: &mut File,
-        is_training: bool,
-        train_size: usize,
-        global_step: usize,
-        epoch: usize,
-    ) -> Result<(f32, f32, usize), Error>
-    where
-        E: SentenceEncoder,
-        E::Encoding: Clone + Eq + Hash,
-    {
-        let epoch_type = if is_training { "train" } else { "validation" };
-
-        let read_progress =
-            ReadProgress::new(file.try_clone()?).or_exit("Cannot create progress bar", 1);
-        let progress_bar = read_progress.progress_bar().clone();
-        progress_bar.set_style(ProgressStyle::default_bar().template(&format!(
-            "[Time: {{elapsed_precise}}, ETA: {{eta_precise}}] {{bar}} {{percent}}% {} {{msg}}",
-            epoch_type
-        )));
-
-        let mut dataset = ConllxDataSet::new(read_progress);
-
+        batches: impl Iterator<Item = Fallible<TensorBuilder<LabelTensor>>>,
+        mut global_step: usize,
+        n_steps: usize,
+    ) -> Result<(f32, f32, usize), Error> {
         let mut instances = 0;
         let mut acc = 0f32;
         let mut loss = 0f32;
-        let mut internal_global_step = global_step;
-        for batch in dataset
-            .batches(
-                encoder,
-                vectorizer,
-                self.batch_size,
-                self.max_len,
-                self.shuffle_buffer_size,
-            )
-            .or_exit("Cannot read batches", 1)
-        {
+        for batch in batches {
             let tensors = batch.or_exit("Cannot read batch", 1).into_parts();
 
-            let batch_perf = if is_training {
-                let lr = if internal_global_step < self.warmup_steps {
-                    (self.initial_lr.into_inner() / (self.warmup_steps as f32))
-                        * internal_global_step as f32
-                } else {
-                    let bytes_done =
-                        (epoch * train_size) + file.seek(SeekFrom::Current(0))? as usize;
-                    let lr_scale = 1f32 - (bytes_done as f32 / (self.epochs * train_size) as f32);
-                    lr_scale * self.initial_lr.into_inner()
-                };
-
-                let batch_perf = trainer.train(
-                    &tensors.seq_lens,
-                    &tensors.inputs,
-                    tensors.subwords.as_ref(),
-                    &tensors.labels,
-                    lr,
-                );
-                progress_bar.set_message(&format!(
-                    "lr: {:.6}, loss: {:.4}, accuracy: {:.4}",
-                    lr, batch_perf.loss, batch_perf.accuracy
-                ));
-                batch_perf
+            let lr = if global_step < self.warmup_steps {
+                (self.initial_lr.into_inner() / (self.warmup_steps as f32)) * global_step as f32
             } else {
-                let batch_perf = trainer.validate(
-                    &tensors.seq_lens,
-                    &tensors.inputs,
-                    tensors.subwords.as_ref(),
-                    &tensors.labels,
-                );
-                progress_bar.set_message(&format!(
-                    "batch loss: {:.4}, batch accuracy: {:.4}",
-                    batch_perf.loss, batch_perf.accuracy
-                ));
-                batch_perf
+                let lr_scale = 1f32 - (global_step as f32 / n_steps as f32);
+                lr_scale * self.initial_lr.into_inner()
             };
+
+            let batch_perf = trainer.train(
+                &tensors.seq_lens,
+                &tensors.inputs,
+                tensors.subwords.as_ref(),
+                &tensors.labels,
+                lr,
+            );
+
+            progress.set_message(&format!(
+                "step: {}, lr: {:.6}, loss: {:.4}, accuracy: {:.4}",
+                global_step, lr, batch_perf.loss, batch_perf.accuracy
+            ));
+            progress.inc(1);
+
+            global_step += 1;
 
             let n_tokens = tensors.seq_lens.view().iter().sum::<i32>();
             loss += n_tokens as f32 * batch_perf.loss;
             acc += n_tokens as f32 * batch_perf.accuracy;
             instances += n_tokens;
-
-            if is_training {
-                internal_global_step += 1;
-
-                saver
-                    .save(trainer, CompletedUnit::Batch(batch_perf.accuracy))
-                    .or_exit("Error saving model", 1);
-            }
         }
 
         loss /= instances as f32;
         acc /= instances as f32;
 
-        Ok((loss, acc, internal_global_step))
+        Ok((loss, acc, global_step))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validation_epoch<E>(
+        &self,
+        trainer: &TaggerTrainer,
+        file: &File,
+        categorical_encoder: &ImmutableCategoricalEncoder<E, E::Encoding>,
+        vectorizer: &SentVectorizer,
+        global_step: usize,
+    ) -> Result<(f32, f32), Error>
+    where
+        E: SentenceEncoder,
+        E::Encoding: Clone + Eq + Hash,
+    {
+        let (mut dataset, progress) = Self::open_dataset_with_progress(&file, "validation")?;
+        let batches = dataset.batches(
+            &categorical_encoder,
+            &vectorizer,
+            self.batch_size,
+            self.max_len,
+            None,
+        )?;
+
+        let (loss, acc) = self.validation_steps(&progress, trainer, batches, global_step)?;
+
+        progress.finish_and_clear();
+
+        Ok((loss, acc))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn validation_steps(
+        &self,
+        progress: &ProgressBar,
+        trainer: &TaggerTrainer,
+        batches: impl Iterator<Item = Fallible<TensorBuilder<LabelTensor>>>,
+        global_step: usize,
+    ) -> Result<(f32, f32), Error> {
+        let mut instances = 0;
+        let mut acc = 0f32;
+        let mut loss = 0f32;
+
+        for batch in batches {
+            let tensors = batch.or_exit("Cannot read batch", 1).into_parts();
+
+            let batch_perf = trainer.validate(
+                &tensors.seq_lens,
+                &tensors.inputs,
+                tensors.subwords.as_ref(),
+                &tensors.labels,
+            );
+
+            progress.set_message(&format!(
+                "step: {}, batch loss: {:.4}, batch accuracy: {:.4}",
+                global_step, batch_perf.loss, batch_perf.accuracy
+            ));
+
+            let n_tokens = tensors.seq_lens.view().iter().sum::<i32>();
+            loss += n_tokens as f32 * batch_perf.loss;
+            acc += n_tokens as f32 * batch_perf.accuracy;
+            instances += n_tokens;
+        }
+
+        loss /= instances as f32;
+        acc /= instances as f32;
+
+        Ok((loss, acc))
     }
 }
 
@@ -292,6 +309,14 @@ impl StickerApp for PretrainApp {
                     .takes_value(true)
                     .value_name("PARAMS")
                     .help("Continue training from parameter files (e.g.: epoch-50)"),
+            )
+            .arg(
+                Arg::with_name(EPOCHS)
+                    .long("epochs")
+                    .takes_value(true)
+                    .value_name("N")
+                    .help("Train for N epochs")
+                    .default_value("2"),
             )
             .arg(
                 Arg::with_name(INITIAL_LR)
@@ -310,13 +335,6 @@ impl StickerApp for PretrainApp {
                     .default_value("0"),
             )
             .arg(
-                Arg::with_name(EPOCHS)
-                    .long("epochs")
-                    .value_name("N")
-                    .help("Number of epochs to pretrain")
-                    .default_value("1"),
-            )
-            .arg(
                 Arg::with_name(MAX_LEN)
                     .long("maxlen")
                     .value_name("N")
@@ -331,11 +349,20 @@ impl StickerApp for PretrainApp {
                     .takes_value(true),
             )
             .arg(
-                Arg::with_name(SAVE_BATCH)
-                    .long("save-batch")
+                Arg::with_name(EVAL_STEPS)
+                    .long("eval_steps")
                     .takes_value(true)
                     .value_name("N")
-                    .help("Save after N batches, in addition to saving after every epoch"),
+                    .help("Evaluate after N steps, save the model on improvement")
+                    .default_value("1000"),
+            )
+            .arg(
+                Arg::with_name(STEPS)
+                    .long("steps")
+                    .value_name("N")
+                    .help("Train for N steps")
+                    .takes_value(true)
+                    .overrides_with(EPOCHS),
             )
             .arg(
                 Arg::with_name(TRAIN_DATA)
@@ -365,11 +392,6 @@ impl StickerApp for PretrainApp {
             .unwrap()
             .parse()
             .or_exit("Cannot parse batch size", 1);
-        let epochs = matches
-            .value_of(EPOCHS)
-            .unwrap()
-            .parse()
-            .or_exit("Cannot parse number of training epochs", 1);
         let initial_lr = matches
             .value_of(INITIAL_LR)
             .unwrap()
@@ -387,18 +409,27 @@ impl StickerApp for PretrainApp {
             .value_of(SHUFFLE)
             .map(|v| v.parse().or_exit("Cannot parse shuffle buffer size.", 1));
         let parameters = matches.value_of(CONTINUE).map(ToOwned::to_owned);
-        let saver = matches
-            .value_of(SAVE_BATCH)
-            .map(|n| {
-                EpochAndBatchesSaver::new(
-                    "pretrain-",
-                    n.parse()
-                        .or_exit("Cannot parse number of batches after which to save", 1),
-                )
-                .into()
-            })
-            .unwrap_or_else(|| EpochSaver::new("pretrain-").into());
+        let eval_steps = matches
+            .value_of(EVAL_STEPS)
+            .unwrap()
+            .parse()
+            .or_exit("Cannot parse number of batches after which to save", 1);
         let logdir = matches.value_of(LOGDIR).map(ToOwned::to_owned);
+
+        // If steps is present, it overrides epochs.
+        let train_duration = if let Some(steps) = matches.value_of(STEPS) {
+            let steps = steps
+                .parse()
+                .or_exit("Cannot parse the number of training steps", 1);
+            TrainDuration::Steps(steps)
+        } else {
+            let epochs = matches
+                .value_of(EPOCHS)
+                .unwrap()
+                .parse()
+                .or_exit("Cannot parse number of training epochs", 1);
+            TrainDuration::Epochs(epochs)
+        };
 
         let train_data = matches.value_of(TRAIN_DATA).unwrap().into();
         let validation_data = matches.value_of(VALIDATION_DATA).unwrap().into();
@@ -406,14 +437,14 @@ impl StickerApp for PretrainApp {
         PretrainApp {
             batch_size,
             config,
-            epochs,
+            eval_steps,
             initial_lr,
             warmup_steps,
             max_len,
             shuffle_buffer_size,
             parameters,
-            saver,
             train_data,
+            train_duration,
             validation_data,
             logdir,
         }
@@ -465,5 +496,45 @@ impl StickerApp for PretrainApp {
                 ),
         }
         .or_exit("Error while training model", 1);
+    }
+}
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrainDuration {
+    Epochs(usize),
+    Steps(usize),
+}
+
+impl TrainDuration {
+    fn to_steps(&self, train_file: &File, batch_size: usize) -> Fallible<usize> {
+        use TrainDuration::*;
+
+        match *self {
+            Epochs(epochs) => {
+                eprintln!("Counting number of steps in an epoch...");
+                let read_progress =
+                    ReadProgress::new(train_file.try_clone()?).or_exit("Cannot open train file", 1);
+
+                let progress_bar = read_progress.progress_bar().clone();
+                progress_bar
+                    .set_style(ProgressStyle::default_bar().template(
+                        "[Time: {elapsed_precise}, ETA: {eta_precise}] {bar} {percent}%",
+                    ));
+
+                let n_sentences = count_conllx_sentences(BufReader::new(read_progress))?;
+
+                progress_bar.finish_and_clear();
+
+                // Compute number of steps of the given batch size.
+                let steps_per_epoch = (n_sentences + batch_size - 1) / batch_size;
+                eprintln!(
+                    "sentences: {}, steps_per epoch: {}, total_steps: {}",
+                    n_sentences,
+                    steps_per_epoch,
+                    epochs * steps_per_epoch
+                );
+                Ok(epochs * steps_per_epoch)
+            }
+            Steps(steps) => Ok(steps),
+        }
     }
 }

--- a/sticker-utils/src/util.rs
+++ b/sticker-utils/src/util.rs
@@ -1,0 +1,16 @@
+use std::io::BufRead;
+
+use failure::Fallible;
+
+pub fn count_conllx_sentences(buf_read: impl BufRead) -> Fallible<usize> {
+    let mut n_sents = 0;
+
+    for line in buf_read.lines() {
+        let line = line?;
+        if line.starts_with("1\t") {
+            n_sents += 1;
+        }
+    }
+
+    Ok(n_sents)
+}

--- a/sticker/src/tensorflow/mod.rs
+++ b/sticker/src/tensorflow/mod.rs
@@ -13,5 +13,6 @@ mod trainer;
 pub use self::trainer::TaggerTrainer;
 
 mod tensor;
+pub use self::tensor::{LabelTensor, TensorBuilder};
 
 mod util;


### PR DESCRIPTION
The main training loop now iterates over a given number of steps
rather than epochs. In each iteration of the loop:

- Gradient descent is performed on the number of steps specified
  by the --eval_steps option (1000 by default).
- The model is evaluated on the given evaluation set.
- If the model improves over the best previous model, the model
  is saved.

Since specifying the overal training length in terms of
steps (--steps) is often not convenient, the length can also be
specified in the number of epochs using the --epochs option.

If the training length is specified in the number of epochs, a quick
pass over the pretraining data is done to count the number of
sentences.

Currently, no Save type is used, because the interface of the savers
is currently not convenient for the pretraining scenario.

Fixes #143 

---

Sorry for the big diff + these training loops are always very imperative and messy :(.