### PR TITLE
Disable auto mixed-precision during prediction

### DIFF
--- a/sticker/src/tensorflow/tagger.rs
+++ b/sticker/src/tensorflow/tagger.rs
@@ -311,11 +311,7 @@ where
     fn new_session(graph: &TaggerGraph) -> Result<Session, Error> {
         let mut session_opts = SessionOptions::new();
         session_opts
-            .set_config(
-                &graph
-                    .model_config
-                    .to_protobuf(graph.has_auto_mixed_precision()?)?,
-            )
+            .set_config(&graph.model_config.to_protobuf(false)?)
             .map_err(status_to_error)?;
 
         Session::new(&session_opts, &graph.graph).map_err(status_to_error)


### PR DESCRIPTION
When using CPU prediction, Grappler will complain about mixed
precision not being available and then performs single-threaded
prediction. Since mixed-precision prediction is primarily for speeding
up training, disable it during prediction.

Fixes #165.