### PR TITLE
Set the default number of warmup steps to 2000

### DIFF
--- a/sticker-utils/src/subcommands/pretrain.rs
+++ b/sticker-utils/src/subcommands/pretrain.rs
@@ -332,7 +332,7 @@ impl StickerApp for PretrainApp {
                     .help(
                         "For the first N timesteps, the learning rate is linearly scaled up to LR.",
                     )
-                    .default_value("0"),
+                    .default_value("2000"),
             )
             .arg(
                 Arg::with_name(MAX_LEN)

--- a/sticker-utils/src/subcommands/train.rs
+++ b/sticker-utils/src/subcommands/train.rs
@@ -278,7 +278,7 @@ impl StickerApp for TrainApp {
                     .help(
                         "For the first N timesteps, the learning rate is linearly scaled up to LR.",
                     )
-                    .default_value("0"),
+                    .default_value("2000"),
             )
             .arg(
                 Arg::with_name(LR_PATIENCE)


### PR DESCRIPTION
Motivation, Ma & Yarats, 2019:

"We conclude by suggesting that practitioners stick to linear warmup
with Adam, with a sensible default being linear warmup over
2·(1−β_2)^−1 training iterations."

We use the default Tensorflow Adam hyperparameters, where β_2 = 0.999,
2·(1−0.999)^−1 = 2000.

Fixes #169.