### PR TITLE
Add {inter,intra}-op-threads command-line options

### DIFF
--- a/sticker-utils/src/traits.rs
+++ b/sticker-utils/src/traits.rs
@@ -54,6 +54,8 @@ pub trait StickerPipelineApp: StickerApp {
 pub trait StickerTrainApp: StickerApp {
     const BATCH_SIZE: &'static str = "BATCH_SIZE";
     const CONFIG: &'static str = "CONFIG";
+    const INTER_OP_THREADS: &'static str = "INTER_OP_THREADS";
+    const INTRA_OP_THREADS: &'static str = "INTRA_OP_THREADS";
 
     fn train_app<'a, 'b>(name: &str) -> App<'a, 'b> {
         App::new(name)
@@ -70,6 +72,18 @@ pub trait StickerTrainApp: StickerApp {
                     .help("Batch size")
                     .long("batchsize")
                     .default_value("256"),
+            )
+            .arg(
+                Arg::with_name(Self::INTER_OP_THREADS)
+                    .help("Inter op parallelism threads")
+                    .long("inter-op-threads")
+                    .default_value("4"),
+            )
+            .arg(
+                Arg::with_name(Self::INTRA_OP_THREADS)
+                    .help("Intra op parallelism threads")
+                    .long("intra-op-threads")
+                    .default_value("4"),
             )
     }
 }

--- a/sticker/src/tensorflow/mod.rs
+++ b/sticker/src/tensorflow/mod.rs
@@ -7,7 +7,7 @@ pub use self::lr::{
 };
 
 mod tagger;
-pub use self::tagger::{ModelConfig, Tagger, TaggerGraph};
+pub use self::tagger::{ModelConfig, RuntimeConfig, Tagger, TaggerGraph};
 
 mod trainer;
 pub use self::trainer::TaggerTrainer;

--- a/sticker/src/wrapper/config.rs
+++ b/sticker/src/wrapper/config.rs
@@ -61,6 +61,14 @@ impl TomlRead for Config {
             eprintln!("The model.batch_size option is deprecated and not used anymore");
         }
 
+        if config.model.intra_op_parallelism_threads.is_some() {
+            eprintln!("The model.intra_op_parallelism option is deprecated and not used anymore");
+        }
+
+        if config.model.inter_op_parallelism_threads.is_some() {
+            eprintln!("The model.inter_op_parallelism option is deprecated and not used anymore");
+        }
+
         if config.labeler.read_ahead.is_some() {
             eprintln!("The labeler.read_ahead option is deprecated and not used anymore");
         }
@@ -234,8 +242,8 @@ mod tests {
                 gpu_allow_growth: true,
                 graph: "sticker.graph".to_owned(),
                 parameters: "sticker.model".to_owned(),
-                intra_op_parallelism_threads: 4,
-                inter_op_parallelism_threads: 4,
+                intra_op_parallelism_threads: Some(4),
+                inter_op_parallelism_threads: Some(4),
             }
         };
     }


### PR DESCRIPTION
These replace the `{inter,intra}_op_parallelism_threads` options in
sticker configuration files. This makes it easier to change the
number of threads.