### PR TITLE
Add EditTreeEncoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "edit_tree"
+version = "0.1.0"
+source = "git+https://github.com/twuebi/edit_tree.git?rev=be5ceb03711ea3cc93ea1df2224c2fa50bf65695#be5ceb03711ea3cc93ea1df2224c2fa50bf65695"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seqalign 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,6 +390,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -829,6 +846,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "schannel"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,6 +875,11 @@ dependencies = [
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "seqalign"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -884,6 +911,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +947,7 @@ version = "0.10.0"
 dependencies = [
  "approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "edit_tree 0.1.0 (git+https://github.com/twuebi/edit_tree.git?rev=be5ceb03711ea3cc93ea1df2224c2fa50bf65695)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "finalfusion 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1182,6 +1220,7 @@ dependencies = [
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum curl 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "d08ad3cb89d076a36b0ce5749eec2c9964f70c0c58480ab6b75a91ec4fc206d8"
 "checksum curl-sys 0.4.21 (registry+https://github.com/rust-lang/crates.io-index)" = "520594da9914c1dc77ce3be450fc1c74fde67c82966d80f8e93c6d460eb0e9ae"
+"checksum edit_tree 0.1.0 (git+https://github.com/twuebi/edit_tree.git?rev=be5ceb03711ea3cc93ea1df2224c2fa50bf65695)" = "<none>"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum encode_unicode 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -1196,6 +1235,7 @@ dependencies = [
 "checksum indicatif 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2c60da1c9abea75996b70a931bba6c750730399005b61ccd853cee50ef3d0d0c"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
@@ -1250,13 +1290,16 @@ dependencies = [
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+"checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+"checksum seqalign 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bca394e52155b436797ed84651ce1d036102480d06048e0a187d76b5bbe49a62"
 "checksum serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "9796c9b7ba2ffe7a9ce53c2287dfc48080f4b2b362fcc245a259b3a7201119dd"
 "checksum serde_cbor 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "318690c4f04ae6553665f3846c0614c9995bb1ea51a2f1c5c4b4ed338c248b49"
 "checksum serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)" = "4b133a43a1ecd55d4086bd5b4dc6c1751c68b1bfbeba7a5040442022c7e7c02e"
+"checksum serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "2f72eb2a68a7dc3f9a691bfda9305a1c017a6215e5a4545c258500d2099a37c2"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum socket2 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "e8b74de517221a2cb01a53349cf54182acdc31a074727d3079068448c0676d85"
 "checksum stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "29f1026ef7b2ded56453d708809e15f148b7f5b6a51e1ee0237964881ab85680"

--- a/sticker-utils/src/subcommands/prepare.rs
+++ b/sticker-utils/src/subcommands/prepare.rs
@@ -12,6 +12,7 @@ use toml;
 
 use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
+use sticker::encoder::lemma::EditTreeEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::serialization::CborWrite;
 use sticker::wrapper::{Config, EncoderType, LabelerType, TomlRead};
@@ -88,6 +89,13 @@ impl StickerApp for PrepareApp {
         let vectorizer = SentVectorizer::new(embeddings, config.input.subwords);
 
         match config.labeler.labeler_type {
+            LabelerType::Lemma => prepare_with_encoder(
+                &config,
+                vectorizer,
+                EditTreeEncoder,
+                treebank_reader,
+                shapes_write,
+            ),
             LabelerType::Sequence(ref layer) => prepare_with_encoder(
                 &config,
                 vectorizer,

--- a/sticker-utils/src/subcommands/pretrain.rs
+++ b/sticker-utils/src/subcommands/pretrain.rs
@@ -12,6 +12,7 @@ use stdinout::OrExit;
 use sticker::encoder::categorical::ImmutableCategoricalEncoder;
 use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
+use sticker::encoder::lemma::EditTreeEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::serialization::CborRead;
 use sticker::tensorflow::{
@@ -488,6 +489,13 @@ impl StickerApp for PretrainApp {
             .or_exit("Cannot construct trainer", 1);
 
         match config.labeler.labeler_type {
+            LabelerType::Lemma => self.train_model_with_encoder::<EditTreeEncoder>(
+                &config,
+                trainer,
+                EditTreeEncoder,
+                train_file,
+                validation_file,
+            ),
             LabelerType::Sequence(ref layer) => self.train_model_with_encoder::<LayerEncoder>(
                 &config,
                 trainer,

--- a/sticker-utils/src/subcommands/print_labels.rs
+++ b/sticker-utils/src/subcommands/print_labels.rs
@@ -6,6 +6,7 @@ use failure::Fallible;
 use stdinout::OrExit;
 use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
+use sticker::encoder::lemma::EditTreeEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::serialization::CborRead;
 use sticker::wrapper::{Config, EncoderType, LabelerType, TomlRead};
@@ -69,6 +70,7 @@ impl StickerApp for PrintLabelsApp {
             .or_exit("Cannot relativize paths in configuration", 1);
 
         match config.labeler.labeler_type {
+            LabelerType::Lemma => self.print_labels_with_encoder::<EditTreeEncoder>(&config),
             LabelerType::Sequence(_) => self.print_labels_with_encoder::<LayerEncoder>(&config),
             LabelerType::Parser(EncoderType::RelativePOS) => {
                 self.print_labels_with_encoder::<RelativePOSEncoder>(&config)

--- a/sticker-utils/src/subcommands/train.rs
+++ b/sticker-utils/src/subcommands/train.rs
@@ -11,6 +11,7 @@ use stdinout::OrExit;
 use sticker::encoder::categorical::ImmutableCategoricalEncoder;
 use sticker::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use sticker::encoder::layer::LayerEncoder;
+use sticker::encoder::lemma::EditTreeEncoder;
 use sticker::encoder::SentenceEncoder;
 use sticker::serialization::CborRead;
 use sticker::tensorflow::{
@@ -435,6 +436,13 @@ impl StickerApp for TrainApp {
         let trainer = create_trainer(&config, self).or_exit("Cannot construct trainer", 1);
 
         match config.labeler.labeler_type {
+            LabelerType::Lemma => self.train_model_with_encoder::<EditTreeEncoder>(
+                &config,
+                trainer,
+                EditTreeEncoder,
+                train_file,
+                validation_file,
+            ),
             LabelerType::Sequence(ref layer) => self.train_model_with_encoder::<LayerEncoder>(
                 &config,
                 trainer,

--- a/sticker/Cargo.toml
+++ b/sticker/Cargo.toml
@@ -13,6 +13,7 @@ license-file = "../LICENSE.md"
 
 [dependencies]
 conllx = "0.12.1"
+edit_tree = { git = "https://github.com/twuebi/edit_tree.git", rev = "be5ceb03711ea3cc93ea1df2224c2fa50bf65695" }
 failure = "0.1"
 finalfusion = "0.10.1"
 itertools = "0.8"

--- a/sticker/src/encoder/lemma/mod.rs
+++ b/sticker/src/encoder/lemma/mod.rs
@@ -1,0 +1,172 @@
+use std::fmt;
+
+use conllx::graph::{Node, Sentence};
+use edit_tree::{Apply, TreeNode};
+use failure::{Error, Fail};
+use serde_derive::{Deserialize, Serialize};
+
+use super::{EncodingProb, SentenceDecoder, SentenceEncoder};
+
+/// Lemma encoding error.
+#[derive(Clone, Debug, Eq, Fail, PartialEq)]
+pub enum EncodeError {
+    /// The token does not have a lemma.
+    #[fail(display = "token without a lemma: '{}'", form)]
+    MissingLemma { form: String },
+}
+
+/// Encoding of a lemmatization as an edit tree.
+#[derive(Clone, Deserialize, Debug, Eq, Hash, PartialEq, Serialize)]
+pub struct EditTree {
+    inner: TreeNode<char>,
+}
+
+impl EditTree {
+    /// Pretty print an edit tree.
+    ///
+    /// This is a pretty printer for edit trees that converts them to
+    /// an S-expr. It is not optimized for efficieny and does a lot of
+    /// string allocations.
+    fn pretty_print(node: &TreeNode<char>) -> String {
+        match node {
+            TreeNode::MatchNode {
+                pre,
+                suf,
+                left,
+                right,
+            } => {
+                let left_str = left
+                    .as_ref()
+                    .map(|left| Self::pretty_print(left))
+                    .unwrap_or_else(|| "()".to_string());
+                let right_str = right
+                    .as_ref()
+                    .map(|right| Self::pretty_print(right))
+                    .unwrap_or_else(|| "()".to_string());
+
+                format!("(match {} {} {} {})", pre, suf, left_str, right_str)
+            }
+            TreeNode::ReplaceNode {
+                replacee,
+                replacement,
+            } => format!(
+                "(replace \"{}\" \"{}\")",
+                replacee.iter().collect::<String>(),
+                replacement.iter().collect::<String>(),
+            ),
+        }
+    }
+}
+
+impl fmt::Display for EditTree {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", Self::pretty_print(&self.inner))
+    }
+}
+
+/// Edit tree-based lemma encoder.
+///
+/// This encoder encodes a lemma as an edit tree that is applied to an
+/// unlemmatized form.
+pub struct EditTreeEncoder;
+
+impl SentenceDecoder for EditTreeEncoder {
+    type Encoding = EditTree;
+
+    fn decode<S>(&self, labels: &[S], sentence: &mut Sentence) -> Result<(), Error>
+    where
+        S: AsRef<[EncodingProb<Self::Encoding>]>,
+    {
+        assert_eq!(
+            labels.len(),
+            sentence.len() - 1,
+            "Labels and sentence length mismatch"
+        );
+
+        for (token, token_labels) in sentence
+            .iter_mut()
+            .filter_map(Node::token_mut)
+            .zip(labels.iter())
+        {
+            if let Some(label) = token_labels.as_ref().get(0) {
+                let form = token.form().chars().collect::<Vec<_>>();
+                let lemma = match label.encoding().inner.apply(&form) {
+                    Some(lemma) => lemma.into_iter().collect::<String>(),
+                    None => continue,
+                };
+
+                token.set_lemma(Some(lemma));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl SentenceEncoder for EditTreeEncoder {
+    type Encoding = EditTree;
+
+    fn encode(&self, sentence: &Sentence) -> Result<Vec<Self::Encoding>, Error> {
+        let mut encoding = Vec::with_capacity(sentence.len() - 1);
+
+        for token in sentence.iter().filter_map(Node::token) {
+            let lemma = token.lemma().ok_or_else(|| EncodeError::MissingLemma {
+                form: token.form().to_owned(),
+            })?;
+
+            let tree = TreeNode::create_tree(
+                &token.form().chars().collect::<Vec<_>>(),
+                &lemma.chars().collect::<Vec<_>>(),
+            );
+
+            encoding.push(EditTree { inner: tree });
+        }
+
+        Ok(encoding)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use conllx::graph::Sentence;
+    use conllx::token::{Token, TokenBuilder};
+    use edit_tree::TreeNode;
+
+    use super::{EditTree, EditTreeEncoder};
+    use crate::encoder::{EncodingProb, SentenceDecoder, SentenceEncoder};
+
+    #[test]
+    fn display_edit_tree() {
+        let tree = EditTree {
+            inner: TreeNode::create_tree(&['l', 'o', 'o', 'p', 't'], &['l', 'o', 'p', 'e', 'n']),
+        };
+
+        assert_eq!(
+            tree.to_string(),
+            "(match 0 3 () (match 1 1 (replace \"o\" \"\") (replace \"t\" \"en\")))"
+        );
+    }
+
+    #[test]
+    fn encoder_decoder_roundtrip() {
+        let mut sent_encode = Sentence::new();
+        sent_encode.push(TokenBuilder::new("hij").lemma("hij").into());
+        sent_encode.push(TokenBuilder::new("heeft").lemma("hebben").into());
+        sent_encode.push(TokenBuilder::new("gefietst").lemma("fietsen").into());
+
+        let encoder = EditTreeEncoder;
+        let labels = encoder
+            .encode(&sent_encode)
+            .unwrap()
+            .into_iter()
+            .map(|encoding| vec![EncodingProb::new(encoding, 1.0)])
+            .collect::<Vec<_>>();
+
+        let mut sent_decode = Sentence::new();
+        sent_decode.push(Token::new("hij"));
+        sent_decode.push(Token::new("heeft"));
+        sent_decode.push(Token::new("gefietst"));
+
+        encoder.decode(&labels, &mut sent_decode).unwrap();
+    }
+}

--- a/sticker/src/encoder/mod.rs
+++ b/sticker/src/encoder/mod.rs
@@ -9,6 +9,8 @@ pub mod deprel;
 
 pub mod layer;
 
+pub mod lemma;
+
 /// An encoding with its probability.
 pub struct EncodingProb<E> {
     encoding: E,

--- a/sticker/src/serialization.rs
+++ b/sticker/src/serialization.rs
@@ -3,6 +3,7 @@
 use std::io::{Read, Write};
 
 use crate::encoder::deprel::{DependencyEncoding, RelativePOS, RelativePosition};
+use crate::encoder::lemma::EditTree;
 use crate::Numberer;
 use failure::Error;
 
@@ -33,6 +34,7 @@ macro_rules! cbor_read {
 
 cbor_read!(Numberer<DependencyEncoding<RelativePOS>>);
 cbor_read!(Numberer<DependencyEncoding<RelativePosition>>);
+cbor_read!(Numberer<EditTree>);
 cbor_read!(Numberer<String>);
 
 pub trait CborWrite {
@@ -58,4 +60,5 @@ macro_rules! cbor_write {
 
 cbor_write!(Numberer<DependencyEncoding<RelativePOS>>);
 cbor_write!(Numberer<DependencyEncoding<RelativePosition>>);
+cbor_write!(Numberer<EditTree>);
 cbor_write!(Numberer<String>);

--- a/sticker/src/wrapper/config.rs
+++ b/sticker/src/wrapper/config.rs
@@ -169,6 +169,7 @@ impl Labeler {
 #[serde(rename_all = "lowercase")]
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum LabelerType {
+    Lemma,
     Parser(EncoderType),
     Sequence(Layer),
 }

--- a/sticker/src/wrapper/tagger.rs
+++ b/sticker/src/wrapper/tagger.rs
@@ -7,6 +7,7 @@ use failure::{Fallible, ResultExt};
 use crate::encoder::categorical::CategoricalEncoder;
 use crate::encoder::deprel::{RelativePOSEncoder, RelativePositionEncoder};
 use crate::encoder::layer::LayerEncoder;
+use crate::encoder::lemma::EditTreeEncoder;
 use crate::encoder::SentenceDecoder;
 use crate::serialization::CborRead;
 use crate::tensorflow::{RuntimeConfig, Tagger as TFTagger, TaggerGraph};
@@ -102,6 +103,9 @@ impl Tagger {
             .with_context(|e| format!("Cannot load computation graph: {}", e))?;
 
         match config.labeler.labeler_type {
+            LabelerType::Lemma => {
+                Self::new_with_decoder(&config, runtime_config, vectorizer, graph, EditTreeEncoder)
+            }
             LabelerType::Sequence(ref layer) => Self::new_with_decoder(
                 &config,
                 runtime_config,


### PR DESCRIPTION
This encoder encodes lemmas as edit trees that can be applied to a
form (using Tobias Pütz' edit_tree crate).

Decoding consists of (attempting to) apply the edit tree to a form.

---

This turned out to be easy to do. Random comments:

* Before merging, it would be nice if there was a release of `edit_tree` on `crates.io`, so that we do not have to rely on a git version.
* In `edit_tree`, the name `TreeNode` is very generic. Maybe it would be clearer to rename this type to `EditTree`? (Each subtree is also an edit tree of some sort.)
* When words are to long (longer than 40 characters by default), any character beyond the maximum length is cut off. For lemmatization, it would probably be nicer to do something more sophisticated (in a separate PR).